### PR TITLE
Adjust layout for calculator and map

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@
   <main class="max-w-6xl mx-auto px-4 py-8 grid grid-cols-1 md:grid-cols-2 gap-6">
 
     <!-- Map -->
-    <section class="bg-white p-6 rounded-lg shadow-md order-1" id="mapSection">
+    <section class="bg-white p-6 rounded-lg shadow-md order-1 md:order-2" id="mapSection">
       <h2 class="text-2xl md:text-3xl font-din-bold mb-4 text-lsh-red">UK office locations</h2>
       <div id="regionToggle" class="flex flex-wrap gap-2 mb-4"></div>
       <div id="map" class="rounded"></div>
@@ -68,7 +68,7 @@
     </section>
 
     <!-- Calculator / Occupancy -->
-    <section class="bg-white p-6 rounded-lg shadow-md order-2" id="calcSection">
+    <section class="bg-white p-6 rounded-lg shadow-md order-2 md:order-1" id="calcSection">
       <div class="mb-4 flex gap-2">
         <button id="calcTab" class="tab-btn active">Space calculator</button>
         <button id="occTab" class="tab-btn">Occupancy costs</button>
@@ -156,6 +156,7 @@
         </table>
       </div>
     </section>
+  </main>
 
   <footer class="text-center text-sm text-gray-400 py-6 font-din-light">© Lambert Smith Hampton — Prototype tool for illustration only.</footer>
 


### PR DESCRIPTION
## Summary
- reorder map and calculator sections so map appears to the right on wider screens
- close the `<main>` element so the footer is outside the grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a28e445a8833284f64954c56df59e