### PR TITLE
Fix map and calculator by correcting JS

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -320,9 +320,8 @@
           const table=document.createElement("table");
           table.className="w-full text-sm border-collapse mb-4";
           table.innerHTML=`<thead><tr class="bg-gray-100"><th class="border px-2 py-1" colspan="2">${d.name}</th></tr></thead><tbody><tr><td class="border px-2 py-1">New build</td><td class="border px-2 py-1">£${d.new}</td></tr><tr><td class="border px-2 py-1">20‑yr old</td><td class="border px-2 py-1">£${d.old}</td></tr></tbody>`; occTables.appendChild(table);
-            nb.style.height=(d.new/max*120)+"px";
-            ob.style.height=(d.old/max*120)+"px";
-          });
+          nb.style.height=(d.new/max*120)+"px";
+          ob.style.height=(d.old/max*120)+"px";
         });
       }
 


### PR DESCRIPTION
## Summary
- fix JS syntax so the map renders and controls work

## Testing
- `node - <<'EOF'
const fs=require('fs');
const html=fs.readFileSync('docs/index.html','utf8');
const script=html.split('<script>')[1].split('</script>')[0];
try{new Function(script); console.log('ok');}catch(e){console.error(e.message);}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687a2f7575248332b0788f351eb37098