### PR TITLE
Integrate cost data into prototype

### DIFF
--- a/docs/costs.js
+++ b/docs/costs.js
@@ -1,0 +1,218 @@
+const COSTS = {
+  "Aberdeen": {
+    "new": 83.93,
+    "old": 83.93
+  },
+  "Basingstoke": {
+    "new": 78.33,
+    "old": 78.33
+  },
+  "Belfast": {
+    "new": 70.55,
+    "old": 70.55
+  },
+  "Birmingham": {
+    "new": 88.33,
+    "old": 88.33
+  },
+  "Bournemouth": {
+    "new": 74.5,
+    "old": 74.5
+  },
+  "Bracknell": {
+    "new": 78.65,
+    "old": 78.65
+  },
+  "Brighton": {
+    "new": 88.98,
+    "old": 88.98
+  },
+  "Bristol": {
+    "new": 89.96,
+    "old": 89.96
+  },
+  "Cambridge": {
+    "new": 114.79,
+    "old": 114.79
+  },
+  "Cardiff": {
+    "new": 73.28,
+    "old": 73.28
+  },
+  "Crawley": {
+    "new": 76.58,
+    "old": 76.58
+  },
+  "Croydon": {
+    "new": 91.26,
+    "old": 91.26
+  },
+  "Edinburgh": {
+    "new": 96.74,
+    "old": 96.74
+  },
+  "Exeter": {
+    "new": 74.36,
+    "old": 74.36
+  },
+  "Farnborough": {
+    "new": 80.28,
+    "old": 80.28
+  },
+  "Glasgow": {
+    "new": 84.26,
+    "old": 84.26
+  },
+  "Guildford": {
+    "new": 91.34,
+    "old": 91.34
+  },
+  "Heathrow": {
+    "new": 88.41,
+    "old": 88.41
+  },
+  "High Wycombe": {
+    "new": 76.89,
+    "old": 76.89
+  },
+  "Leeds": {
+    "new": 83.37,
+    "old": 83.37
+  },
+  "Leicester": {
+    "new": 65.33,
+    "old": 65.33
+  },
+  "Liverpool": {
+    "new": 69.24,
+    "old": 69.24
+  },
+  "London - City": {
+    "new": 146.83,
+    "old": 146.83
+  },
+  "London - Docklands": {
+    "new": 113.01,
+    "old": 113.01
+  },
+  "London \u0096 Hammersmith": {
+    "new": 121.71,
+    "old": 121.71
+  },
+  "London \u0096 Midtown": {
+    "new": 136.51,
+    "old": 136.51
+  },
+  "London - Southbank": {
+    "new": 142.78,
+    "old": 142.78
+  },
+  "London - West End Core": {
+    "new": 217.65,
+    "old": 217.65
+  },
+  "London-West End non-core": {
+    "new": 175.25,
+    "old": 175.25
+  },
+  "Luton": {
+    "new": 73.13,
+    "old": 73.13
+  },
+  "Maidenhead": {
+    "new": 91.2,
+    "old": 91.2
+  },
+  "Maidstone": {
+    "new": 77.01,
+    "old": 77.01
+  },
+  "Manchester": {
+    "new": 97.33,
+    "old": 97.33
+  },
+  "Milton Keynes": {
+    "new": 76.15,
+    "old": 76.15
+  },
+  "Newcastle": {
+    "new": 77.31,
+    "old": 77.31
+  },
+  "Northampton": {
+    "new": 67.74,
+    "old": 67.74
+  },
+  "Norwich": {
+    "new": 62.9,
+    "old": 62.9
+  },
+  "Nottingham": {
+    "new": 70.58,
+    "old": 70.58
+  },
+  "Oxford": {
+    "new": 113.29,
+    "old": 113.29
+  },
+  "Portsmouth": {
+    "new": 79.45,
+    "old": 79.45
+  },
+  "Preston": {
+    "new": 63.83,
+    "old": 63.83
+  },
+  "Reading": {
+    "new": 91.47,
+    "old": 91.47
+  },
+  "Richmond": {
+    "new": 119.69,
+    "old": 119.69
+  },
+  "Sheffield": {
+    "new": 74.56,
+    "old": 74.56
+  },
+  "Slough": {
+    "new": 87.29,
+    "old": 87.29
+  },
+  "Southampton": {
+    "new": 86.43,
+    "old": 86.43
+  },
+  "St Albans": {
+    "new": 96.44,
+    "old": 96.44
+  },
+  "Staines": {
+    "new": 90.98,
+    "old": 90.98
+  },
+  "Swansea": {
+    "new": 59.63,
+    "old": 59.63
+  },
+  "Swindon": {
+    "new": 70.31,
+    "old": 70.31
+  },
+  "Uxbridge": {
+    "new": 85.41,
+    "old": 85.41
+  },
+  "Warrington": {
+    "new": 69.98,
+    "old": 69.98
+  },
+  "Watford": {
+    "new": 89.38,
+    "old": 89.38
+  },
+  "Woking": {
+    "new": 87.74,
+    "old": 87.74
+  }
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,6 +149,7 @@
   <footer class="text-center text-sm text-gray-400 py-6 font-din-light">© Lambert Smith Hampton — Prototype tool for illustration only.</footer>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+  <script src="costs.js"></script>
   <script>
     if(typeof L==='undefined'){console.error('Leaflet failed to load.');}
     (function(){
@@ -211,7 +212,7 @@
         {name:'Warrington',coords:[53.3925,-2.5802],region:'North West'}
       ];
 
-      // assign placeholder rent values for each location
+      // assign placeholder rent values for calculator
       const BASE = {};
       LOCS.forEach((loc,i)=>{ const val=200 + i*10; loc.base=val; BASE[loc.name]=val; });
 
@@ -306,11 +307,11 @@
           const nb=document.createElement("div");
           nb.className="occ-bar-new text-white text-xs flex items-center justify-center w-8";
           nb.style.height="0px";
-          nb.textContent="£"+d.new;
+          nb.textContent="£"+d.new.toFixed(2);
           const ob=document.createElement("div");
           ob.className="occ-bar-old text-white text-xs flex items-center justify-center w-8";
           ob.style.height="0px";
-          ob.textContent="£"+d.old;
+          ob.textContent="£"+d.old.toFixed(2);
           bars.appendChild(nb); bars.appendChild(ob);
           const labs=document.createElement("div");
           labs.className="flex justify-between w-full text-xs mt-1";
@@ -319,7 +320,7 @@
           occBars.appendChild(col);
           const table=document.createElement("table");
           table.className="w-full text-sm border-collapse mb-4";
-          table.innerHTML=`<thead><tr class="bg-gray-100"><th class="border px-2 py-1" colspan="2">${d.name}</th></tr></thead><tbody><tr><td class="border px-2 py-1">New build</td><td class="border px-2 py-1">£${d.new}</td></tr><tr><td class="border px-2 py-1">20‑yr old</td><td class="border px-2 py-1">£${d.old}</td></tr></tbody>`; occTables.appendChild(table);
+          table.innerHTML=`<thead><tr class="bg-gray-100"><th class="border px-2 py-1" colspan="2">${d.name}</th></tr></thead><tbody><tr><td class="border px-2 py-1">New build</td><td class="border px-2 py-1">£${d.new.toFixed(2)}</td></tr><tr><td class="border px-2 py-1">20‑yr old</td><td class="border px-2 py-1">£${d.old.toFixed(2)}</td></tr></tbody>`; occTables.appendChild(table);
           nb.style.height=(d.new/max*120)+"px";
           ob.style.height=(d.old/max*120)+"px";
         });
@@ -388,10 +389,13 @@
         let choicePopup=null;
         function resetMarkers(){Object.values(markers).forEach(m=>m.setStyle({stroke:false,color:'var(--lsh-red)',fillColor:'var(--lsh-red)'}));}
         LOCS.forEach(loc=>{
-          const base=BASE[loc.name];
           const marker=L.circleMarker(loc.coords,{radius:6,stroke:false,color:'var(--lsh-red)',fillColor:'var(--lsh-red)',fillOpacity:0.9});
-          const newRent=base!==undefined?Math.round(base*AGE.New):null;
-          marker.bindTooltip(base!==undefined?`<strong>${loc.name}</strong><br/>New build: £${newRent}/m²<br/>20‑yr build: £${base}/m²`:`<strong>${loc.name}</strong>`,{direction:'top',offset:[0,-8]});
+          const cost=COSTS[loc.name];
+          if(cost){
+            marker.bindTooltip(`<strong>${loc.name}</strong><br/>New build: £${cost.new.toFixed(2)} per sq ft<br/>20‑year old: £${cost.old.toFixed(2)} per sq ft`,{direction:'top',offset:[0,-8]});
+          }else{
+            marker.bindTooltip(`<strong>${loc.name}</strong>`,{direction:'top',offset:[0,-8]});
+          }
           marker.on('mouseover',function(){this.openTooltip();});
           marker.on('mouseout',function(){this.closeTooltip();});
           marker.on('click',()=>{
@@ -401,8 +405,9 @@
             marker.openTooltip();
             if(!resWrap.classList.contains('hidden')) performCalc();
             if(occTab.classList.contains('active')){
-              const baseCost=BASE[loc.name];
-              const newCost=Math.round(baseCost*AGE.New);
+              const cost=COSTS[loc.name]||{new:null,old:null};
+              const newCost=cost.new;
+              const oldCost=cost.old;
               if(choicePopup) map.closePopup(choicePopup);
               if(occData.length>0){
                 const content=`<div class="compare-popup flex gap-2"><button class="btn btn-red" id="cmpBtn">Compare</button><button class="btn btn-gray" id="repBtn">Replace</button></div>`;
@@ -414,17 +419,17 @@
                   document.getElementById('cmpBtn').addEventListener('click',()=>{
                     map.closePopup(choicePopup); choicePopup=null;
                     if(occData.length>=5){alert('Maximum 5 locations'); return;}
-                    occData.push({name:loc.name,new:newCost,old:baseCost});
+                    occData.push({name:loc.name,new:newCost,old:oldCost});
                     updateOccUI();
                   });
                   document.getElementById('repBtn').addEventListener('click',()=>{
                     map.closePopup(choicePopup); choicePopup=null;
-                    occData[occData.length-1]={name:loc.name,new:newCost,old:baseCost};
+                    occData[occData.length-1]={name:loc.name,new:newCost,old:oldCost};
                     updateOccUI();
                   });
                 },0);
               }else{
-                occData=[{name:loc.name,new:newCost,old:baseCost}];
+                occData=[{name:loc.name,new:newCost,old:oldCost}];
                 updateOccUI();
               }
             }


### PR DESCRIPTION
## Summary
- add `costs.js` dataset with total cost data per location
- show new build and 20‑year old costs on map tooltips
- show precise cost values in Occupancy Costs comparison UI
- wire up map click handling to use the new cost data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a3e87d888833293960eb34f3f576f