### PR TITLE
Update occupancy cost data from CSV

### DIFF
--- a/docs/costs.js
+++ b/docs/costs.js
@@ -1,218 +1,1192 @@
-const COSTS = {
+const COSTS =
+{
   "Aberdeen": {
-    "new": 83.93,
-    "old": 83.93
+    "new": {
+      "netEffectiveRent": 30.06,
+      "rates": 10.27,
+      "annualisedCosts": 9.59,
+      "hardFM": 21.58,
+      "softFM": 10.39,
+      "managementFees": 2.03,
+      "totalSqft": 83.93,
+      "totalWorkstation": 8392.0
+    },
+    "old": {
+      "netEffectiveRent": 20.56,
+      "rates": 9.332759531,
+      "annualisedCosts": 9.5944,
+      "hardFM": 25.74062234,
+      "softFM": 10.390016,
+      "managementFees": 1.74,
+      "totalSqft": 77.35779788,
+      "totalWorkstation": 7735.0
+    }
   },
   "Basingstoke": {
-    "new": 78.33,
-    "old": 78.33
+    "new": {
+      "netEffectiveRent": 23.93,
+      "rates": 11.11,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.57,
+      "softFM": 10.43,
+      "managementFees": 1.87,
+      "totalSqft": 78.33,
+      "totalWorkstation": 7833.0
+    },
+    "old": {
+      "netEffectiveRent": 15.26,
+      "rates": 9.092081159,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.9810467,
+      "softFM": 10.430016,
+      "managementFees": 1.57,
+      "totalSqft": 71.75434386,
+      "totalWorkstation": 7175.0
+    }
   },
   "Belfast": {
-    "new": 70.55,
-    "old": 70.55
+    "new": {
+      "netEffectiveRent": 21.0,
+      "rates": 8.76,
+      "annualisedCosts": 9.59,
+      "hardFM": 19.27,
+      "softFM": 10.17,
+      "managementFees": 1.75,
+      "totalSqft": 70.55,
+      "totalWorkstation": 7054.0
+    },
+    "old": {
+      "netEffectiveRent": 16.2,
+      "rates": 6.7,
+      "annualisedCosts": 9.5944,
+      "hardFM": 23.91187866,
+      "softFM": 10.170016,
+      "managementFees": 1.58,
+      "totalSqft": 68.15629466,
+      "totalWorkstation": 6815.0
+    }
   },
   "Birmingham": {
-    "new": 88.33,
-    "old": 88.33
+    "new": {
+      "netEffectiveRent": 33.0,
+      "rates": 12.83,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.12,
+      "softFM": 10.6,
+      "managementFees": 2.19,
+      "totalSqft": 88.33,
+      "totalWorkstation": 8833.0
+    },
+    "old": {
+      "netEffectiveRent": 26.0,
+      "rates": 10.33039028,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.63725589,
+      "softFM": 10.600016,
+      "managementFees": 1.96,
+      "totalSqft": 83.12206217,
+      "totalWorkstation": 8312.0
+    }
   },
   "Bournemouth": {
-    "new": 74.5,
-    "old": 74.5
+    "new": {
+      "netEffectiveRent": 24.3,
+      "rates": 7.91,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.59,
+      "softFM": 10.26,
+      "managementFees": 1.85,
+      "totalSqft": 74.5,
+      "totalWorkstation": 7449.0
+    },
+    "old": {
+      "netEffectiveRent": 18.98,
+      "rates": 5.533610889,
+      "annualisedCosts": 9.5944,
+      "hardFM": 25.01801242,
+      "softFM": 10.260016,
+      "managementFees": 1.7,
+      "totalSqft": 71.08603931,
+      "totalWorkstation": 7108.0
+    }
   },
   "Bracknell": {
-    "new": 78.65,
-    "old": 78.65
+    "new": {
+      "netEffectiveRent": 26.4,
+      "rates": 8.93,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.51,
+      "softFM": 10.43,
+      "managementFees": 1.96,
+      "totalSqft": 78.65,
+      "totalWorkstation": 7865.0
+    },
+    "old": {
+      "netEffectiveRent": 18.98,
+      "rates": 8.246613797,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.86354443,
+      "softFM": 10.430016,
+      "managementFees": 1.7,
+      "totalSqft": 74.64137423,
+      "totalWorkstation": 7464.0
+    }
   },
   "Brighton": {
-    "new": 88.98,
-    "old": 88.98
+    "new": {
+      "netEffectiveRent": 34.69,
+      "rates": 10.46,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.71,
+      "softFM": 10.51,
+      "managementFees": 2.19,
+      "totalSqft": 88.98,
+      "totalWorkstation": 8898.0
+    },
+    "old": {
+      "netEffectiveRent": 27.0,
+      "rates": 9.789324614,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.07446079,
+      "softFM": 10.510016,
+      "managementFees": 1.94,
+      "totalSqft": 84.7350014,
+      "totalWorkstation": 8473.0
+    }
   },
   "Bristol": {
-    "new": 89.96,
-    "old": 89.96
+    "new": {
+      "netEffectiveRent": 35.77,
+      "rates": 11.28,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.49,
+      "softFM": 10.56,
+      "managementFees": 2.27,
+      "totalSqft": 89.96,
+      "totalWorkstation": 8996.0
+    },
+    "old": {
+      "netEffectiveRent": 29.75,
+      "rates": 7.548733412,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.9080874,
+      "softFM": 10.560016,
+      "managementFees": 2.05,
+      "totalSqft": 84.41123681,
+      "totalWorkstation": 8441.0
+    }
   },
   "Cambridge": {
-    "new": 114.79,
-    "old": 114.79
+    "new": {
+      "netEffectiveRent": 50.88,
+      "rates": 20.17,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.24,
+      "softFM": 10.35,
+      "managementFees": 2.72,
+      "totalSqft": 114.79,
+      "totalWorkstation": 11478.0
+    },
+    "old": {
+      "netEffectiveRent": 35.0,
+      "rates": 15.4998519,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.68003568,
+      "softFM": 10.350016,
+      "managementFees": 2.23,
+      "totalSqft": 98.18110359,
+      "totalWorkstation": 9818.0
+    }
   },
   "Cardiff": {
-    "new": 73.28,
-    "old": 73.28
+    "new": {
+      "netEffectiveRent": 21.46,
+      "rates": 9.98,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.13,
+      "softFM": 10.35,
+      "managementFees": 1.77,
+      "totalSqft": 73.28,
+      "totalWorkstation": 7327.0
+    },
+    "old": {
+      "netEffectiveRent": 13.73,
+      "rates": 8.885579846,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.5438182,
+      "softFM": 10.350016,
+      "managementFees": 1.51,
+      "totalSqft": 68.61381405,
+      "totalWorkstation": 6861.0
+    }
   },
   "Crawley": {
-    "new": 76.58,
-    "old": 76.58
+    "new": {
+      "netEffectiveRent": 23.1,
+      "rates": 10.36,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.47,
+      "softFM": 10.39,
+      "managementFees": 1.84,
+      "totalSqft": 76.58,
+      "totalWorkstation": 7658.0
+    },
+    "old": {
+      "netEffectiveRent": 18.15,
+      "rates": 8.56375039,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.90489748,
+      "softFM": 10.390016,
+      "managementFees": 1.67,
+      "totalSqft": 74.09986387,
+      "totalWorkstation": 7409.0
+    }
   },
   "Croydon": {
-    "new": 91.26,
-    "old": 91.26
+    "new": {
+      "netEffectiveRent": 32.81,
+      "rates": 14.8,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.82,
+      "softFM": 10.26,
+      "managementFees": 2.15,
+      "totalSqft": 91.26,
+      "totalWorkstation": 9126.0
+    },
+    "old": {
+      "netEffectiveRent": 25.81,
+      "rates": 10.00192742,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.08435853,
+      "softFM": 10.260016,
+      "managementFees": 1.91,
+      "totalSqft": 83.48750195,
+      "totalWorkstation": 8348.0
+    }
   },
   "Edinburgh": {
-    "new": 96.74,
-    "old": 96.74
+    "new": {
+      "netEffectiveRent": 41.44,
+      "rates": 10.89,
+      "annualisedCosts": 9.59,
+      "hardFM": 21.92,
+      "softFM": 10.51,
+      "managementFees": 2.38,
+      "totalSqft": 96.74,
+      "totalWorkstation": 9673.0
+    },
+    "old": {
+      "netEffectiveRent": 28.5,
+      "rates": 9.322098389,
+      "annualisedCosts": 9.5944,
+      "hardFM": 26.11533708,
+      "softFM": 10.510016,
+      "managementFees": 1.97,
+      "totalSqft": 86.01185147,
+      "totalWorkstation": 8601.0
+    }
   },
   "Exeter": {
-    "new": 74.36,
-    "old": 74.36
+    "new": {
+      "netEffectiveRent": 23.13,
+      "rates": 9.28,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.12,
+      "softFM": 10.43,
+      "managementFees": 1.81,
+      "totalSqft": 74.36,
+      "totalWorkstation": 7435.0
+    },
+    "old": {
+      "netEffectiveRent": 19.89,
+      "rates": 5.205245462,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.49905883,
+      "softFM": 10.430016,
+      "managementFees": 1.7,
+      "totalSqft": 71.31872029,
+      "totalWorkstation": 7131.0
+    }
   },
   "Farnborough": {
-    "new": 80.28,
-    "old": 80.28
+    "new": {
+      "netEffectiveRent": 25.99,
+      "rates": 11.03,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.39,
+      "softFM": 10.51,
+      "managementFees": 1.94,
+      "totalSqft": 80.28,
+      "totalWorkstation": 8027.0
+    },
+    "old": {
+      "netEffectiveRent": 18.56,
+      "rates": 8.720879255,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.71963985,
+      "softFM": 10.510016,
+      "managementFees": 1.69,
+      "totalSqft": 74.62173511,
+      "totalWorkstation": 7462.0
+    }
   },
   "Glasgow": {
-    "new": 84.26,
-    "old": 84.26
+    "new": {
+      "netEffectiveRent": 29.29,
+      "rates": 10.92,
+      "annualisedCosts": 9.59,
+      "hardFM": 21.89,
+      "softFM": 10.51,
+      "managementFees": 2.06,
+      "totalSqft": 84.26,
+      "totalWorkstation": 8426.0
+    },
+    "old": {
+      "netEffectiveRent": 24.75,
+      "rates": 7.4409441,
+      "annualisedCosts": 9.5944,
+      "hardFM": 26.14460996,
+      "softFM": 10.510016,
+      "managementFees": 1.9,
+      "totalSqft": 80.33997006,
+      "totalWorkstation": 8033.0
+    }
   },
   "Guildford": {
-    "new": 91.34,
-    "old": 91.34
+    "new": {
+      "netEffectiveRent": 33.0,
+      "rates": 14.47,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.8,
+      "softFM": 10.47,
+      "managementFees": 2.19,
+      "totalSqft": 91.34,
+      "totalWorkstation": 9134.0
+    },
+    "old": {
+      "netEffectiveRent": 21.04,
+      "rates": 12.48259172,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.18022749,
+      "softFM": 10.470016,
+      "managementFees": 1.77,
+      "totalSqft": 81.36403521,
+      "totalWorkstation": 8136.0
+    }
   },
   "Heathrow": {
-    "new": 88.41,
-    "old": 88.41
+    "new": {
+      "netEffectiveRent": 32.3,
+      "rates": 11.61,
+      "annualisedCosts": 10.42,
+      "hardFM": 21.24,
+      "softFM": 10.68,
+      "managementFees": 2.15,
+      "totalSqft": 88.41,
+      "totalWorkstation": 8840.0
+    },
+    "old": {
+      "netEffectiveRent": 24.75,
+      "rates": 8.879168917,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.26343989,
+      "softFM": 10.680016,
+      "managementFees": 1.9,
+      "totalSqft": 81.89382481,
+      "totalWorkstation": 8189.0
+    }
   },
   "High Wycombe": {
-    "new": 76.89,
-    "old": 76.89
+    "new": {
+      "netEffectiveRent": 22.69,
+      "rates": 11.04,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.52,
+      "softFM": 10.39,
+      "managementFees": 1.83,
+      "totalSqft": 76.89,
+      "totalWorkstation": 7688.0
+    },
+    "old": {
+      "netEffectiveRent": 17.33,
+      "rates": 4.756759862,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.88215776,
+      "softFM": 10.390016,
+      "managementFees": 1.64,
+      "totalSqft": 69.42013362,
+      "totalWorkstation": 6942.0
+    }
   },
   "Leeds": {
-    "new": 83.37,
-    "old": 83.37
+    "new": {
+      "netEffectiveRent": 30.53,
+      "rates": 10.66,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.02,
+      "softFM": 10.47,
+      "managementFees": 2.1,
+      "totalSqft": 83.37,
+      "totalWorkstation": 8337.0
+    },
+    "old": {
+      "netEffectiveRent": 22.28,
+      "rates": 8.828669023,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.49356969,
+      "softFM": 10.470016,
+      "managementFees": 1.81,
+      "totalSqft": 77.47665471,
+      "totalWorkstation": 7747.0
+    }
   },
   "Leicester": {
-    "new": 65.33,
-    "old": 65.33
+    "new": {
+      "netEffectiveRent": 16.5,
+      "rates": 7.46,
+      "annualisedCosts": 9.59,
+      "hardFM": 19.85,
+      "softFM": 10.31,
+      "managementFees": 1.61,
+      "totalSqft": 65.33,
+      "totalWorkstation": 6532.0
+    },
+    "old": {
+      "netEffectiveRent": 15.26,
+      "rates": 5.409342594,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.33524751,
+      "softFM": 10.310016,
+      "managementFees": 1.57,
+      "totalSqft": 66.4790061,
+      "totalWorkstation": 6647.0
+    }
   },
   "Liverpool": {
-    "new": 69.24,
-    "old": 69.24
+    "new": {
+      "netEffectiveRent": 21.04,
+      "rates": 6.5,
+      "annualisedCosts": 9.59,
+      "hardFM": 19.99,
+      "softFM": 10.35,
+      "managementFees": 1.77,
+      "totalSqft": 69.24,
+      "totalWorkstation": 6924.0
+    },
+    "old": {
+      "netEffectiveRent": 16.5,
+      "rates": 5.99179,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.44802983,
+      "softFM": 10.350016,
+      "managementFees": 1.61,
+      "totalSqft": 68.49423583,
+      "totalWorkstation": 6849.0
+    }
   },
   "London - City": {
-    "new": 146.83,
-    "old": 146.83
+    "new": {
+      "netEffectiveRent": 68.06,
+      "rates": 30.77,
+      "annualisedCosts": 11.25,
+      "hardFM": 22.07,
+      "softFM": 11.27,
+      "managementFees": 3.41,
+      "totalSqft": 146.83,
+      "totalWorkstation": 14682.0
+    },
+    "old": {
+      "netEffectiveRent": 40.3,
+      "rates": 21.04339714,
+      "annualisedCosts": 11.248,
+      "hardFM": 25.98886413,
+      "softFM": 11.270016,
+      "managementFees": 2.48,
+      "totalSqft": 112.3302773,
+      "totalWorkstation": 11233.0
+    }
   },
   "London - Docklands": {
-    "new": 113.01,
-    "old": 113.01
+    "new": {
+      "netEffectiveRent": 42.63,
+      "rates": 23.47,
+      "annualisedCosts": 11.25,
+      "hardFM": 22.13,
+      "softFM": 10.97,
+      "managementFees": 2.57,
+      "totalSqft": 113.01,
+      "totalWorkstation": 11301.0
+    },
+    "old": {
+      "netEffectiveRent": 24.27,
+      "rates": 16.56649793,
+      "annualisedCosts": 11.248,
+      "hardFM": 26.07396971,
+      "softFM": 10.970016,
+      "managementFees": 1.92,
+      "totalSqft": 91.04848363,
+      "totalWorkstation": 9104.0
+    }
   },
-  "London \u0096 Hammersmith": {
-    "new": 121.71,
-    "old": 121.71
+  "London \u2013 Hammersmith": {
+    "new": {
+      "netEffectiveRent": 49.88,
+      "rates": 24.82,
+      "annualisedCosts": 11.25,
+      "hardFM": 22.01,
+      "softFM": 11.02,
+      "managementFees": 2.73,
+      "totalSqft": 121.71,
+      "totalWorkstation": 12171.0
+    },
+    "old": {
+      "netEffectiveRent": 33.0,
+      "rates": 23.35649226,
+      "annualisedCosts": 11.248,
+      "hardFM": 25.93520363,
+      "softFM": 11.020016,
+      "managementFees": 2.19,
+      "totalSqft": 106.7497119,
+      "totalWorkstation": 10674.0
+    }
   },
-  "London \u0096 Midtown": {
-    "new": 136.51,
-    "old": 136.51
+  "London \u2013 Midtown": {
+    "new": {
+      "netEffectiveRent": 66.0,
+      "rates": 22.56,
+      "annualisedCosts": 11.25,
+      "hardFM": 22.11,
+      "softFM": 11.27,
+      "managementFees": 3.33,
+      "totalSqft": 136.51,
+      "totalWorkstation": 13651.0
+    },
+    "old": {
+      "netEffectiveRent": 45.38,
+      "rates": 19.72468334,
+      "annualisedCosts": 11.248,
+      "hardFM": 26.02621201,
+      "softFM": 11.270016,
+      "managementFees": 2.62,
+      "totalSqft": 116.2689114,
+      "totalWorkstation": 11626.0
+    }
   },
   "London - Southbank": {
-    "new": 142.78,
-    "old": 142.78
+    "new": {
+      "netEffectiveRent": 64.35,
+      "rates": 30.86,
+      "annualisedCosts": 11.25,
+      "hardFM": 22.02,
+      "softFM": 11.02,
+      "managementFees": 3.28,
+      "totalSqft": 142.78,
+      "totalWorkstation": 14278.0
+    },
+    "old": {
+      "netEffectiveRent": 42.9,
+      "rates": 22.12292243,
+      "annualisedCosts": 11.248,
+      "hardFM": 25.9580077,
+      "softFM": 11.020016,
+      "managementFees": 2.53,
+      "totalSqft": 115.7789461,
+      "totalWorkstation": 11577.0
+    }
   },
   "London - West End Core": {
-    "new": 217.65,
-    "old": 217.65
+    "new": {
+      "netEffectiveRent": 113.63,
+      "rates": 54.26,
+      "annualisedCosts": 11.25,
+      "hardFM": 22.3,
+      "softFM": 11.27,
+      "managementFees": 4.95,
+      "totalSqft": 217.65,
+      "totalWorkstation": 21765.0
+    },
+    "old": {
+      "netEffectiveRent": 61.88,
+      "rates": 49.28887078,
+      "annualisedCosts": 11.248,
+      "hardFM": 26.23261733,
+      "softFM": 11.270016,
+      "managementFees": 3.19,
+      "totalSqft": 163.1095041,
+      "totalWorkstation": 16310.0
+    }
   },
   "London-West End non-core": {
-    "new": 175.25,
-    "old": 175.25
+    "new": {
+      "netEffectiveRent": 81.64,
+      "rates": 45.29,
+      "annualisedCosts": 11.25,
+      "hardFM": 21.95,
+      "softFM": 11.27,
+      "managementFees": 3.85,
+      "totalSqft": 175.25,
+      "totalWorkstation": 17524.0
+    },
+    "old": {
+      "netEffectiveRent": 56.1,
+      "rates": 28.95569425,
+      "annualisedCosts": 11.248,
+      "hardFM": 25.86761836,
+      "softFM": 11.270016,
+      "managementFees": 2.99,
+      "totalSqft": 136.4313286,
+      "totalWorkstation": 13643.0
+    }
   },
   "Luton": {
-    "new": 73.13,
-    "old": 73.13
+    "new": {
+      "netEffectiveRent": 21.88,
+      "rates": 7.93,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.42,
+      "softFM": 10.37,
+      "managementFees": 2.11,
+      "totalSqft": 73.13,
+      "totalWorkstation": 7312.0
+    },
+    "old": {
+      "netEffectiveRent": 13.5,
+      "rates": 7.608525,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.85199192,
+      "softFM": 10.370016,
+      "managementFees": 1.93,
+      "totalSqft": 68.68173292,
+      "totalWorkstation": 6868.0
+    }
   },
   "Maidenhead": {
-    "new": 91.2,
-    "old": 91.2
+    "new": {
+      "netEffectiveRent": 33.83,
+      "rates": 13.85,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.57,
+      "softFM": 10.31,
+      "managementFees": 2.22,
+      "totalSqft": 91.2,
+      "totalWorkstation": 9120.0
+    },
+    "old": {
+      "netEffectiveRent": 25.58,
+      "rates": 11.85323481,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.95704965,
+      "softFM": 10.310016,
+      "managementFees": 1.93,
+      "totalSqft": 85.05150047,
+      "totalWorkstation": 8505.0
+    }
   },
   "Maidstone": {
-    "new": 77.01,
-    "old": 77.01
+    "new": {
+      "netEffectiveRent": 24.05,
+      "rates": 9.91,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.53,
+      "softFM": 10.26,
+      "managementFees": 1.84,
+      "totalSqft": 77.01,
+      "totalWorkstation": 7701.0
+    },
+    "old": {
+      "netEffectiveRent": 17.5,
+      "rates": 9.025323476,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.97473438,
+      "softFM": 10.260016,
+      "managementFees": 1.63,
+      "totalSqft": 73.81127386,
+      "totalWorkstation": 7381.0
+    }
   },
   "Manchester": {
-    "new": 97.33,
-    "old": 97.33
+    "new": {
+      "netEffectiveRent": 39.78,
+      "rates": 14.83,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.34,
+      "softFM": 10.43,
+      "managementFees": 2.36,
+      "totalSqft": 97.33,
+      "totalWorkstation": 9733.0
+    },
+    "old": {
+      "netEffectiveRent": 30.06,
+      "rates": 10.539675,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.86667845,
+      "softFM": 10.430016,
+      "managementFees": 2.03,
+      "totalSqft": 87.52076945,
+      "totalWorkstation": 8752.0
+    }
   },
   "Milton Keynes": {
-    "new": 76.15,
-    "old": 76.15
+    "new": {
+      "netEffectiveRent": 24.75,
+      "rates": 8.21,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.5,
+      "softFM": 10.39,
+      "managementFees": 1.87,
+      "totalSqft": 76.15,
+      "totalWorkstation": 7614.0
+    },
+    "old": {
+      "netEffectiveRent": 21.15,
+      "rates": 5.439495258,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.97075523,
+      "softFM": 10.390016,
+      "managementFees": 1.75,
+      "totalSqft": 74.12146648,
+      "totalWorkstation": 7412.0
+    }
   },
   "Newcastle": {
-    "new": 77.31,
-    "old": 77.31
+    "new": {
+      "netEffectiveRent": 25.75,
+      "rates": 9.76,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.14,
+      "softFM": 10.14,
+      "managementFees": 1.92,
+      "totalSqft": 77.31,
+      "totalWorkstation": 7730.0
+    },
+    "old": {
+      "netEffectiveRent": 21.88,
+      "rates": 9.019607409,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.58752905,
+      "softFM": 10.140016,
+      "managementFees": 1.79,
+      "totalSqft": 77.01155245,
+      "totalWorkstation": 7701.0
+    }
   },
   "Northampton": {
-    "new": 67.74,
-    "old": 67.74
+    "new": {
+      "netEffectiveRent": 20.25,
+      "rates": 6.07,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.06,
+      "softFM": 10.05,
+      "managementFees": 1.72,
+      "totalSqft": 67.74,
+      "totalWorkstation": 6774.0
+    },
+    "old": {
+      "netEffectiveRent": 13.5,
+      "rates": 5.050720447,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.53376646,
+      "softFM": 10.050016,
+      "managementFees": 1.49,
+      "totalSqft": 64.21890291,
+      "totalWorkstation": 6421.0
+    }
   },
   "Norwich": {
-    "new": 62.9,
-    "old": 62.9
+    "new": {
+      "netEffectiveRent": 14.03,
+      "rates": 7.97,
+      "annualisedCosts": 9.59,
+      "hardFM": 19.72,
+      "softFM": 10.05,
+      "managementFees": 1.53,
+      "totalSqft": 62.9,
+      "totalWorkstation": 6289.0
+    },
+    "old": {
+      "netEffectiveRent": 10.73,
+      "rates": 5.074305306,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.23213697,
+      "softFM": 10.050016,
+      "managementFees": 1.43,
+      "totalSqft": 61.11085827,
+      "totalWorkstation": 6111.0
+    }
   },
   "Nottingham": {
-    "new": 70.58,
-    "old": 70.58
+    "new": {
+      "netEffectiveRent": 21.88,
+      "rates": 7.31,
+      "annualisedCosts": 9.59,
+      "hardFM": 19.97,
+      "softFM": 10.05,
+      "managementFees": 1.78,
+      "totalSqft": 70.58,
+      "totalWorkstation": 7058.0
+    },
+    "old": {
+      "netEffectiveRent": 16.09,
+      "rates": 4.667119863,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.46679661,
+      "softFM": 10.050016,
+      "managementFees": 1.6,
+      "totalSqft": 66.46833247,
+      "totalWorkstation": 6646.0
+    }
   },
   "Oxford": {
-    "new": 113.29,
-    "old": 113.29
+    "new": {
+      "netEffectiveRent": 57.81,
+      "rates": 10.85,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.57,
+      "softFM": 10.68,
+      "managementFees": 2.95,
+      "totalSqft": 113.29,
+      "totalWorkstation": 11328.0
+    },
+    "old": {
+      "netEffectiveRent": 37.0,
+      "rates": 9.092995636,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.02661436,
+      "softFM": 10.680016,
+      "managementFees": 2.26,
+      "totalSqft": 94.48082599,
+      "totalWorkstation": 9448.0
+    }
   },
   "Portsmouth": {
-    "new": 79.45,
-    "old": 79.45
+    "new": {
+      "netEffectiveRent": 27.75,
+      "rates": 8.74,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.28,
+      "softFM": 10.31,
+      "managementFees": 1.96,
+      "totalSqft": 79.45,
+      "totalWorkstation": 7945.0
+    },
+    "old": {
+      "netEffectiveRent": 21.0,
+      "rates": 7.320496797,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.73479738,
+      "softFM": 10.310016,
+      "managementFees": 1.75,
+      "totalSqft": 75.53651018,
+      "totalWorkstation": 7553.0
+    }
   },
   "Preston": {
-    "new": 63.83,
-    "old": 63.83
+    "new": {
+      "netEffectiveRent": 17.5,
+      "rates": 4.8,
+      "annualisedCosts": 9.59,
+      "hardFM": 19.96,
+      "softFM": 10.35,
+      "managementFees": 1.63,
+      "totalSqft": 63.83,
+      "totalWorkstation": 6383.0
+    },
+    "old": {
+      "netEffectiveRent": 9.63,
+      "rates": 2.7728,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.45123365,
+      "softFM": 10.350016,
+      "managementFees": 1.39,
+      "totalSqft": 58.18844965,
+      "totalWorkstation": 5818.0
+    }
   },
   "Reading": {
-    "new": 91.47,
-    "old": 91.47
+    "new": {
+      "netEffectiveRent": 33.0,
+      "rates": 14.94,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.53,
+      "softFM": 10.39,
+      "managementFees": 2.19,
+      "totalSqft": 91.47,
+      "totalWorkstation": 9147.0
+    },
+    "old": {
+      "netEffectiveRent": 25.58,
+      "rates": 10.38748708,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.01502761,
+      "softFM": 10.390016,
+      "managementFees": 1.93,
+      "totalSqft": 83.7237307,
+      "totalWorkstation": 8372.0
+    }
   },
   "Richmond": {
-    "new": 119.69,
-    "old": 119.69
+    "new": {
+      "netEffectiveRent": 54.63,
+      "rates": 20.27,
+      "annualisedCosts": 10.42,
+      "hardFM": 21.02,
+      "softFM": 10.51,
+      "managementFees": 2.83,
+      "totalSqft": 119.69,
+      "totalWorkstation": 11968.0
+    },
+    "old": {
+      "netEffectiveRent": 42.75,
+      "rates": 17.78292878,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.40010252,
+      "softFM": 10.510016,
+      "managementFees": 2.47,
+      "totalSqft": 109.3342473,
+      "totalWorkstation": 10933.0
+    }
   },
   "Sheffield": {
-    "new": 74.56,
-    "old": 74.56
+    "new": {
+      "netEffectiveRent": 23.6,
+      "rates": 9.02,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.24,
+      "softFM": 10.26,
+      "managementFees": 1.85,
+      "totalSqft": 74.56,
+      "totalWorkstation": 7456.0
+    },
+    "old": {
+      "netEffectiveRent": 15.57,
+      "rates": 4.788124638,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.4672418,
+      "softFM": 10.260016,
+      "managementFees": 1.58,
+      "totalSqft": 66.25978243,
+      "totalWorkstation": 6625.0
+    }
   },
   "Slough": {
-    "new": 87.29,
-    "old": 87.29
+    "new": {
+      "netEffectiveRent": 31.35,
+      "rates": 12.21,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.66,
+      "softFM": 10.51,
+      "managementFees": 2.13,
+      "totalSqft": 87.29,
+      "totalWorkstation": 8728.0
+    },
+    "old": {
+      "netEffectiveRent": 16.5,
+      "rates": 8.778536243,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.13607076,
+      "softFM": 10.510016,
+      "managementFees": 1.61,
+      "totalSqft": 72.955823,
+      "totalWorkstation": 7295.0
+    }
   },
   "Southampton": {
-    "new": 86.43,
-    "old": 86.43
+    "new": {
+      "netEffectiveRent": 32.38,
+      "rates": 10.74,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.39,
+      "softFM": 10.39,
+      "managementFees": 2.11,
+      "totalSqft": 86.43,
+      "totalWorkstation": 8643.0
+    },
+    "old": {
+      "netEffectiveRent": 26.36,
+      "rates": 9.757890888,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.84374871,
+      "softFM": 10.390016,
+      "managementFees": 1.91,
+      "totalSqft": 83.6828556,
+      "totalWorkstation": 8368.0
+    }
   },
   "St Albans": {
-    "new": 96.44,
-    "old": 96.44
+    "new": {
+      "netEffectiveRent": 39.31,
+      "rates": 13.45,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.49,
+      "softFM": 10.43,
+      "managementFees": 2.34,
+      "totalSqft": 96.44,
+      "totalWorkstation": 9643.0
+    },
+    "old": {
+      "netEffectiveRent": 30.06,
+      "rates": 10.68093207,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.94401749,
+      "softFM": 10.430016,
+      "managementFees": 2.03,
+      "totalSqft": 88.56616556,
+      "totalWorkstation": 8856.0
+    }
   },
   "Staines": {
-    "new": 90.98,
-    "old": 90.98
+    "new": {
+      "netEffectiveRent": 32.81,
+      "rates": 14.57,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.52,
+      "softFM": 10.51,
+      "managementFees": 2.15,
+      "totalSqft": 90.98,
+      "totalWorkstation": 9098.0
+    },
+    "old": {
+      "netEffectiveRent": 24.75,
+      "rates": 10.60201421,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.99512997,
+      "softFM": 10.510016,
+      "managementFees": 1.9,
+      "totalSqft": 83.17836018,
+      "totalWorkstation": 8317.0
+    }
   },
   "Swansea": {
-    "new": 59.63,
-    "old": 59.63
+    "new": {
+      "netEffectiveRent": 12.4,
+      "rates": 5.42,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.12,
+      "softFM": 10.29,
+      "managementFees": 1.81,
+      "totalSqft": 59.63,
+      "totalWorkstation": 5962.0
+    },
+    "old": {
+      "netEffectiveRent": 8.25,
+      "rates": 2.8494,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.57778151,
+      "softFM": 10.290016,
+      "managementFees": 1.51,
+      "totalSqft": 57.07159751,
+      "totalWorkstation": 5707.0
+    }
   },
   "Swindon": {
-    "new": 70.31,
-    "old": 70.31
+    "new": {
+      "netEffectiveRent": 18.56,
+      "rates": 9.9,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.4,
+      "softFM": 10.17,
+      "managementFees": 1.69,
+      "totalSqft": 70.31,
+      "totalWorkstation": 7031.0
+    },
+    "old": {
+      "netEffectiveRent": 12.67,
+      "rates": 8.065538834,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.90121515,
+      "softFM": 10.170016,
+      "managementFees": 1.49,
+      "totalSqft": 66.89116999,
+      "totalWorkstation": 6689.0
+    }
   },
   "Uxbridge": {
-    "new": 85.41,
-    "old": 85.41
+    "new": {
+      "netEffectiveRent": 31.5,
+      "rates": 9.54,
+      "annualisedCosts": 10.42,
+      "hardFM": 21.33,
+      "softFM": 10.51,
+      "managementFees": 2.11,
+      "totalSqft": 85.41,
+      "totalWorkstation": 8541.0
+    },
+    "old": {
+      "netEffectiveRent": 22.75,
+      "rates": 7.212012254,
+      "annualisedCosts": 10.4212,
+      "hardFM": 25.38997274,
+      "softFM": 10.510016,
+      "managementFees": 1.81,
+      "totalSqft": 78.093201,
+      "totalWorkstation": 7809.0
+    }
   },
   "Warrington": {
-    "new": 69.98,
-    "old": 69.98
+    "new": {
+      "netEffectiveRent": 20.35,
+      "rates": 7.9,
+      "annualisedCosts": 9.59,
+      "hardFM": 20.24,
+      "softFM": 10.29,
+      "managementFees": 1.6,
+      "totalSqft": 69.98,
+      "totalWorkstation": 6997.0
+    },
+    "old": {
+      "netEffectiveRent": 14.66,
+      "rates": 5.1,
+      "annualisedCosts": 9.5944,
+      "hardFM": 24.73496233,
+      "softFM": 10.290016,
+      "managementFees": 1.45,
+      "totalSqft": 65.82937833,
+      "totalWorkstation": 6582.0
+    }
   },
   "Watford": {
-    "new": 89.38,
-    "old": 89.38
+    "new": {
+      "netEffectiveRent": 32.85,
+      "rates": 12.89,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.57,
+      "softFM": 10.51,
+      "managementFees": 2.14,
+      "totalSqft": 89.38,
+      "totalWorkstation": 8937.0
+    },
+    "old": {
+      "netEffectiveRent": 27.47,
+      "rates": 11.29117705,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.99872473,
+      "softFM": 10.510016,
+      "managementFees": 1.98,
+      "totalSqft": 86.67111778,
+      "totalWorkstation": 8667.0
+    }
   },
   "Woking": {
-    "new": 87.74,
-    "old": 87.74
+    "new": {
+      "netEffectiveRent": 30.53,
+      "rates": 13.75,
+      "annualisedCosts": 10.42,
+      "hardFM": 20.43,
+      "softFM": 10.51,
+      "managementFees": 2.1,
+      "totalSqft": 87.74,
+      "totalWorkstation": 8774.0
+    },
+    "old": {
+      "netEffectiveRent": 19.8,
+      "rates": 11.38079104,
+      "annualisedCosts": 10.4212,
+      "hardFM": 24.80988704,
+      "softFM": 10.510016,
+      "managementFees": 1.73,
+      "totalSqft": 78.65189408,
+      "totalWorkstation": 7865.0
+    }
   }
-};
+}
+;

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,7 +295,7 @@
         }
         occPrompt.classList.add("hidden");
         occWrap.classList.remove("hidden");
-        const max=Math.max(...occData.flatMap(d=>[d.new,d.old]));
+        const max=Math.max(...occData.flatMap(d=>[d.new.totalSqft,d.old.totalSqft]));
         occData.forEach(d=>{
           const col=document.createElement("div");
           col.className="flex flex-col items-center";
@@ -307,11 +307,11 @@
           const nb=document.createElement("div");
           nb.className="occ-bar-new text-white text-xs flex items-center justify-center w-8";
           nb.style.height="0px";
-          nb.textContent="£"+d.new.toFixed(2);
+          nb.textContent="£"+d.new.totalSqft.toFixed(2);
           const ob=document.createElement("div");
           ob.className="occ-bar-old text-white text-xs flex items-center justify-center w-8";
           ob.style.height="0px";
-          ob.textContent="£"+d.old.toFixed(2);
+          ob.textContent="£"+d.old.totalSqft.toFixed(2);
           bars.appendChild(nb); bars.appendChild(ob);
           const labs=document.createElement("div");
           labs.className="flex justify-between w-full text-xs mt-1";
@@ -320,9 +320,19 @@
           occBars.appendChild(col);
           const table=document.createElement("table");
           table.className="w-full text-sm border-collapse mb-4";
-          table.innerHTML=`<thead><tr class="bg-gray-100"><th class="border px-2 py-1" colspan="2">${d.name}</th></tr></thead><tbody><tr><td class="border px-2 py-1">New build</td><td class="border px-2 py-1">£${d.new.toFixed(2)}</td></tr><tr><td class="border px-2 py-1">20‑yr old</td><td class="border px-2 py-1">£${d.old.toFixed(2)}</td></tr></tbody>`; occTables.appendChild(table);
-          nb.style.height=(d.new/max*120)+"px";
-          ob.style.height=(d.old/max*120)+"px";
+          const headers=['Net Effective Rent','Rates','Annualised costs','Hard FM','Soft FM','Management Fees','TOTAL /sq ft','Total per workstation'];
+          const keys=['netEffectiveRent','rates','annualisedCosts','hardFM','softFM','managementFees','totalSqft','totalWorkstation'];
+          const headRow='<tr class="bg-gray-100"><th class="border px-2 py-1">Building age</th>'+headers.map(h=>`<th class="border px-2 py-1">${h}</th>`).join('')+'</tr>';
+          function buildRow(label,obj){
+            return '<tr><td class="border px-2 py-1">'+label+'</td>'+keys.map(k=>{
+              const v=obj[k];
+              return `<td class="border px-2 py-1">£${k==='totalWorkstation'?Math.round(v).toLocaleString():v.toFixed(2)}</td>`;
+            }).join('')+'</tr>';
+          }
+          table.innerHTML=`<thead><tr class="bg-gray-100"><th class="border px-2 py-1" colspan="${keys.length+1}">${d.name}</th></tr>${headRow}</thead><tbody>${buildRow('New build',d.new)}${buildRow('20‑yr old',d.old)}</tbody>`;
+          occTables.appendChild(table);
+          nb.style.height=(d.new.totalSqft/max*120)+"px";
+          ob.style.height=(d.old.totalSqft/max*120)+"px";
         });
       }
 
@@ -392,7 +402,7 @@
           const marker=L.circleMarker(loc.coords,{radius:6,stroke:false,color:'var(--lsh-red)',fillColor:'var(--lsh-red)',fillOpacity:0.9});
           const cost=COSTS[loc.name];
           if(cost){
-            marker.bindTooltip(`<strong>${loc.name}</strong><br/>New build: £${cost.new.toFixed(2)} per sq ft<br/>20‑year old: £${cost.old.toFixed(2)} per sq ft`,{direction:'top',offset:[0,-8]});
+            marker.bindTooltip(`<strong>${loc.name}</strong><br/>New build: £${cost.new.totalSqft.toFixed(2)} per sq ft<br/>20‑year old: £${cost.old.totalSqft.toFixed(2)} per sq ft`,{direction:'top',offset:[0,-8]});
           }else{
             marker.bindTooltip(`<strong>${loc.name}</strong>`,{direction:'top',offset:[0,-8]});
           }


### PR DESCRIPTION
## Summary
- populate `docs/costs.js` from the updated CSV with full cost breakdowns
- display complete cost data in `Occupancy costs` tables for each location
- update tooltips and charts to use the revised data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a41e8bef48332bd8c90620b5636e8