### PR TITLE
Fix map markers for All UK region

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -450,7 +450,7 @@
         function showMarkers(region){
           Object.values(markers).forEach(m=>{ if(map.hasLayer(m)) m.remove(); });
           LOCS.forEach(loc=>{
-            if(loc.main || (region!=='All UK' && loc.region===region)){
+            if(region==='All UK' || loc.region===region || loc.main){
               markers[loc.name].addTo(map);
             }
           });


### PR DESCRIPTION
## Summary
- update marker display logic so the `All UK` view shows every location instead of just major ones

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a486163cc8332b867ab497f99bd9c