### PR TITLE
Fix map markers with correct names

### DIFF
--- a/docs/costs.js
+++ b/docs/costs.js
@@ -528,7 +528,7 @@ const COSTS =
       "totalWorkstation": 9104.0
     }
   },
-  "London \u2013 Hammersmith": {
+  "London – Hammersmith": {
     "new": {
       "netEffectiveRent": 49.88,
       "rates": 24.82,
@@ -550,7 +550,7 @@ const COSTS =
       "totalWorkstation": 10674.0
     }
   },
-  "London \u2013 Midtown": {
+  "London – Midtown": {
     "new": {
       "netEffectiveRent": 66.0,
       "rates": 22.56,
@@ -616,7 +616,7 @@ const COSTS =
       "totalWorkstation": 16310.0
     }
   },
-  "London-West End non-core": {
+  "London - West End non-core": {
     "new": {
       "netEffectiveRent": 81.64,
       "rates": 45.29,

--- a/docs/index.html
+++ b/docs/index.html
@@ -450,7 +450,7 @@
         function showMarkers(region){
           Object.values(markers).forEach(m=>{ if(map.hasLayer(m)) m.remove(); });
           LOCS.forEach(loc=>{
-            if(region==='All UK' || loc.region===region || loc.main){
+            if(loc.main || (region!=='All UK' && loc.region===region)){
               markers[loc.name].addTo(map);
             }
           });


### PR DESCRIPTION
## Summary
- align London location names in `costs.js` with those in `index.html`
- restore original marker display logic so only key locations show for "All UK"

## Testing
- `node -e "require('./docs/costs.js'); console.log('loaded cost data');"`

------
https://chatgpt.com/codex/tasks/task_e_687a49d5c28c8332a54350fce91112b7