### PR TITLE
Improve occupancy costs layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -327,9 +327,9 @@
         const max=Math.max(...occData.flatMap(d=>[d.new.totalSqft,d.old.totalSqft]));
         occData.forEach(d=>{
           const col=document.createElement("div");
-          col.className="flex flex-col items-center p-2 border rounded";
+          col.className="flex flex-col items-center p-2 border rounded h-56 justify-between";
           const label=document.createElement("div");
-          label.className="text-sm font-din-bold mb-1 text-center min-h-6";
+          label.className="text-sm font-din-bold mb-1 text-center h-10 flex items-center justify-center";
           label.textContent=d.name;
           const bars=document.createElement("div");
           bars.className="flex items-end gap-2";
@@ -343,22 +343,22 @@
           ob.innerHTML=`<div class="bar-label">£${d.old.totalSqft.toFixed(2)}<br><small>psf</small></div>`;
           bars.appendChild(nb); bars.appendChild(ob);
           const labs=document.createElement("div");
-          labs.className="flex justify-between w-full text-[0.65rem] mt-1";
-          labs.innerHTML="<span>New build</span><span>20yr-old</span>";
+          labs.className="flex gap-2 mt-1";
+          labs.innerHTML='<span class="text-[0.55rem] w-12 text-center">New build</span><span class="text-[0.55rem] w-12 text-center">20yr-old</span>';
           col.appendChild(label); col.appendChild(bars); col.appendChild(labs);
           occBars.appendChild(col);
           const table=document.createElement("table");
           table.className="w-full text-sm border-collapse mb-4";
           const headers=['Total','Net effective rent','Rates','Annualised costs','Hard FM','Soft FM','Management fees','Total per workstation'];
           const keys=['totalSqft','netEffectiveRent','rates','annualisedCosts','hardFM','softFM','managementFees','totalWorkstation'];
-          const headRow='<tr class="bg-gray-100"><th class="border px-2 py-1">Building age</th>'+headers.map((h,i)=>`<th class="border px-2 py-1${i>=4?' extra-col':''}">${h}</th>`).join('')+'</tr>';
+          const headRow='<tr class="bg-gray-100"><th class="border px-2 py-1 text-center">Building age</th>'+headers.map((h,i)=>`<th class="border px-2 py-1 text-center${i>=4?' extra-col':''}">${h}</th>`).join('')+'</tr>';
           function buildRow(label,obj){
-            return '<tr><td class="border px-2 py-1">'+label+'</td>'+keys.map((k,i)=>{
+            return '<tr><td class="border px-2 py-1 text-center">'+label+'</td>'+keys.map((k,i)=>{
               const v=obj[k];
-              return `<td class="border px-2 py-1${i>=4?' extra-col':''}">£${k==='totalWorkstation'?Math.round(v).toLocaleString():v.toFixed(2)}</td>`;
+              return `<td class="border px-2 py-1 text-center${i>=4?' extra-col':''}">£${k==='totalWorkstation'?Math.round(v).toLocaleString():v.toFixed(2)}</td>`;
             }).join('')+'</tr>';
           }
-          table.innerHTML=`<thead><tr class="bg-gray-100"><th class="border px-2 py-1" colspan="${keys.length+1}">${d.name}</th></tr>${headRow}</thead><tbody>${buildRow('New build',d.new)}${buildRow('20‑yr old',d.old)}</tbody>`;
+          table.innerHTML=`<thead><tr class="bg-gray-100"><th class="border px-2 py-1 text-center" colspan="${keys.length+1}">${d.name}</th></tr>${headRow}</thead><tbody>${buildRow('New build',d.new)}${buildRow('20‑yr old',d.old)}</tbody>`;
           occTables.appendChild(table);
           nb.style.height=(d.new.totalSqft/max*120)+"px";
           ob.style.height=(d.old.totalSqft/max*120)+"px";


### PR DESCRIPTION
## Summary
- tweak bar layout and location labels
- adjust bar labels
- center table data

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a6c2fe60483328cc7760c5acb14c8