### PR TITLE
Update occupancy cost UI behaviour

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,9 +53,9 @@
     /* table extra columns hidden until expanded */
     .extra-col{display:none;}
     #occTables.expanded .extra-col{display:table-cell;}
-    /* expand section to full width when tables expanded */
+    /* expand section to the left when tables expanded */
     @media (min-width:768px){
-      #calcSection.expanded{grid-column:1 / -1;}
+      #calcSection.expanded{position:relative;width:calc(100% + 20rem);left:-20rem;}
     }
   </style>
 </head>
@@ -151,10 +151,11 @@
         <div class="flex justify-between items-center mb-4">
           <button id="occClear" class="bg-gray-200 hover:bg-gray-300 text-sm px-3 py-1 rounded font-din-bold">Clear</button>
         </div>
-        <div id="occBars" class="flex gap-4 items-end mb-4"></div>
+        <div id="occBars" class="flex gap-4 items-end mb-4 w-full"></div>
         <div id="occExpandWrap" class="flex justify-end mb-2">
           <button id="occExpand" class="bg-gray-200 hover:bg-gray-300 text-sm px-3 py-1 rounded font-din-bold">Expand</button>
         </div>
+        <p id="occLimitMsg" class="hidden text-xs text-lsh-red mb-2">You can compare up to 3 locations.</p>
         <div id="occTables"></div>
         <p class="text-xs text-gray-500" id="occUnits">All costs are per sq ft.</p>
       </div>
@@ -261,7 +262,7 @@
       const calcWrap=$('calcWrapper'); const occWrap=$('occWrapper');
       const calcTab=$('calcTab'); const occTab=$('occTab');
       const occBars=$("occBars"); const occTables=$("occTables"); const occClear=$("occClear"); const occPrompt=$("occPrompt"); const occExpand=$("occExpand");
-      const occExpandWrap=$('occExpandWrap');
+      const occExpandWrap=$('occExpandWrap'); const occLimitMsg=$('occLimitMsg');
       const calcSection=$("calcSection");
       let expanded=false;
       let occData=[];
@@ -299,10 +300,9 @@
           occPrompt.classList.add('hidden');
         }else{
           calcWrap.classList.add('hidden');
-          occWrap.classList.remove('hidden');
           calcTab.classList.remove('active');
           occTab.classList.add('active');
-          if(occData.length===0) occPrompt.classList.remove('hidden');
+          updateOccUI();
         }
       }
       calcTab.addEventListener('click',()=>switchTab('calc'));
@@ -311,6 +311,7 @@
       function updateOccUI(){
         occBars.innerHTML="";
         occTables.innerHTML="";
+        occLimitMsg.classList.add('hidden');
        if(occData.length===0){
          occWrap.classList.add("hidden");
          occPrompt.classList.remove("hidden");
@@ -327,24 +328,24 @@
         const max=Math.max(...occData.flatMap(d=>[d.new.totalSqft,d.old.totalSqft]));
         occData.forEach(d=>{
           const col=document.createElement("div");
-          col.className="flex flex-col items-center p-2 border rounded h-56 justify-between";
+          col.className="flex-1 flex flex-col items-center p-2 border rounded h-56 justify-between";
           const label=document.createElement("div");
           label.className="text-sm font-din-bold mb-1 text-center h-10 flex items-center justify-center";
           label.textContent=d.name;
           const bars=document.createElement("div");
           bars.className="flex items-end gap-2";
           const nb=document.createElement("div");
-          nb.className="occ-bar-new text-white text-xs flex items-center justify-center w-12";
+          nb.className="occ-bar-new text-white text-xs flex items-center justify-center w-16";
           nb.style.height="0px";
           nb.innerHTML=`<div class="bar-label">£${d.new.totalSqft.toFixed(2)}<br><small>psf</small></div>`;
           const ob=document.createElement("div");
-          ob.className="occ-bar-old text-white text-xs flex items-center justify-center w-12";
+          ob.className="occ-bar-old text-white text-xs flex items-center justify-center w-16";
           ob.style.height="0px";
           ob.innerHTML=`<div class="bar-label">£${d.old.totalSqft.toFixed(2)}<br><small>psf</small></div>`;
           bars.appendChild(nb); bars.appendChild(ob);
           const labs=document.createElement("div");
           labs.className="flex gap-2 mt-1";
-          labs.innerHTML='<span class="text-[0.55rem] w-12 text-center">New build</span><span class="text-[0.55rem] w-12 text-center">20yr-old</span>';
+          labs.innerHTML='<span class="text-[0.45rem] w-16 text-center">New build</span><span class="text-[0.45rem] w-16 text-center">20yr-old</span>';
           col.appendChild(label); col.appendChild(bars); col.appendChild(labs);
           occBars.appendChild(col);
           const table=document.createElement("table");
@@ -368,7 +369,7 @@
         occExpand.textContent = expanded ? 'Collapse' : 'Expand';
       }
 
-      occClear.addEventListener('click',()=>{occData=[]; updateOccUI();});
+      occClear.addEventListener('click',()=>{occData=[]; document.getElementById('occLimitMsg').classList.add('hidden'); updateOccUI();});
       occExpand.addEventListener('click',()=>{expanded=!expanded; updateOccUI();});
 
       // auto‑comma budget
@@ -463,17 +464,23 @@
                 setTimeout(()=>{
                   document.getElementById('cmpBtn').addEventListener('click',()=>{
                     map.closePopup(choicePopup); choicePopup=null;
-                    if(occData.length>=5){alert('Maximum 5 locations'); return;}
+                    if(occData.length>=3){
+                      document.getElementById('occLimitMsg').classList.remove('hidden');
+                      return;
+                    }
+                    document.getElementById('occLimitMsg').classList.add('hidden');
                     occData.push({name:loc.name,new:newCost,old:oldCost});
                     updateOccUI();
                   });
                   document.getElementById('repBtn').addEventListener('click',()=>{
                     map.closePopup(choicePopup); choicePopup=null;
+                    document.getElementById('occLimitMsg').classList.add('hidden');
                     occData[occData.length-1]={name:loc.name,new:newCost,old:oldCost};
                     updateOccUI();
                   });
                 },0);
               }else{
+                document.getElementById('occLimitMsg').classList.add('hidden');
                 occData=[{name:loc.name,new:newCost,old:oldCost}];
                 updateOccUI();
               }


### PR DESCRIPTION
## Summary
- tweak Occupancy costs UI
- reduce allowed comparison to 3 locations
- hide clear/expand buttons until a location is chosen
- enlarge bars and reduce text under bars
- expand tile out to the left when showing extra columns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a729f08888332b80bf0e9b9575979