### PR TITLE
Reduce font size for occupancy labels

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -343,7 +343,7 @@
           bars.appendChild(nb); bars.appendChild(ob);
           const labs=document.createElement("div");
           labs.className="flex gap-2 mt-1";
-          labs.innerHTML='<span class="text-[0.55rem] w-16 text-center">New build</span><span class="text-[0.55rem] w-16 text-center">20-yr old</span>';
+          labs.innerHTML='<span class="text-[0.45rem] w-16 text-center whitespace-nowrap">New build</span><span class="text-[0.45rem] w-16 text-center whitespace-nowrap">20-yr old</span>';
           col.appendChild(label); col.appendChild(bars); col.appendChild(labs);
           occBars.appendChild(col);
           const table=document.createElement("table");


### PR DESCRIPTION
## Summary
- shrink occupancy bar labels to 0.45rem and prevent wrapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f76dcb5c083329c765adac97420ca