### PR TITLE
Fix layout and map overlap

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -50,7 +50,8 @@
     .result-scroll.need-scroll{overflow-x:auto;}
     .result-title{white-space:nowrap;}
     #resultContainer.compare .result-value{font-size:1.5rem;}
-    #resultContainer.single{text-align:left;}
+    #resultContainer.single{text-align:left;grid-template-columns:1fr;}
+    @media (min-width:768px){#resultContainer.single{grid-template-columns:1fr;}}
     #resultContainer.compare{text-align:center;}
     .tab-btn{padding:0.5rem 1rem;border-bottom:2px solid transparent;}
     .tab-btn.active{border-color:var(--lsh-red);color:var(--lsh-red);font-weight:700;}
@@ -649,10 +650,11 @@
         resultContainer.classList.add('single');
        resultContainer.classList.remove('compare');
        }
-       resWrap.classList.remove('hidden');
-       resWrap.classList.remove('fade-in'); void resWrap.offsetWidth; resWrap.classList.add('fade-in');
-       updateComparePrompt();
-       updateScrollbars();
+        resWrap.classList.remove('hidden');
+        resWrap.classList.remove('fade-in'); void resWrap.offsetWidth; resWrap.classList.add('fade-in');
+        updateComparePrompt();
+        updateScrollbars();
+        setTimeout(updateScrollbars,50);
       }
 
       calcBtn.addEventListener('click',performCalc);
@@ -733,7 +735,7 @@
               map.setView(coords[0], map.getZoom());
             }else if(coords.length===2){
               map.once('moveend',openTips);
-              map.fitBounds(L.latLngBounds(coords),{padding:[60,60],maxZoom:8});
+              map.fitBounds(L.latLngBounds(coords),{padding:[60,60],maxZoom:11});
             }else{
               openTips();
             }


### PR DESCRIPTION
## Summary
- stretch result panel when only one location is chosen
- re-check scrollbars after render
- zoom in closer when comparing two locations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880c7136b08833281a1c106d04a4b61