### PR TITLE
Fix Sheffield text in location dropdown

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -80,6 +80,7 @@
     button:active{transform:scale(.95);}
     .fade-in{animation:fadeIn .3s ease;}
     @keyframes fadeIn{from{opacity:0;transform:translateY(.5rem);}to{opacity:1;transform:translateY(0);}}
+    select,option{font-family:'DINPro','DIN Pro',Arial,sans-serif;font-feature-settings:'liga' 0;-webkit-font-feature-settings:'liga' 0;}
   </style>
 </head>
 <body class="bg-gray-50 antialiased">


### PR DESCRIPTION
## Summary
- ensure dropdowns use DINPro and disable ligatures so names like "Sheffield" display correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688101de1e488332b4d93a64e5054551