### PR TITLE
Remove DIN font from dropdowns

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,8 @@
     button:active{transform:scale(.95);}
     .fade-in{animation:fadeIn .3s ease;}
     @keyframes fadeIn{from{opacity:0;transform:translateY(.5rem);}to{opacity:1;transform:translateY(0);}}
-    select,option{font-family:'DINPro','DIN Pro',Arial,sans-serif;font-feature-settings:'liga' 0;-webkit-font-feature-settings:'liga' 0;}
+    /* Use a DIN-like system font for dropdowns to avoid Sheffield ligature issues */
+    select,option{font-family:'Helvetica Neue',Arial,sans-serif;font-feature-settings:'liga' 0;-webkit-font-feature-settings:'liga' 0;}
   </style>
 </head>
 <body class="bg-gray-50 antialiased">


### PR DESCRIPTION
## Summary
- switch dropdown `select` and `option` font to Helvetica/Arial
- comment to explain fix for Sheffield ligature

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883a08e7c388332bf60c08414320a76