### PR TITLE
Adjust area result font size when comparing locations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -50,6 +50,8 @@
     .result-scroll.need-scroll{overflow-x:auto;}
     .result-title{white-space:nowrap;}
     #resultContainer.compare .result-value{font-size:1.5rem;}
+    #resultContainer.compare #areaResult1 .result-value,
+    #resultContainer.compare #areaResult2 .result-value{font-size:1.35rem;}
     #resultContainer.single{text-align:left;grid-template-columns:1fr;}
     @media (min-width:768px){#resultContainer.single{grid-template-columns:1fr;}}
     #resultContainer.compare{text-align:center;}


### PR DESCRIPTION
## Summary
- refine compare-mode styling so area results use a slightly smaller font when two locations are shown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888c49789e08332b2f209399cc11a43