### PR TITLE
Add standalone data download page and link

### DIFF
--- a/docs/data.html
+++ b/docs/data.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>TOCS Data Download</title>
+</head>
+<body>
+  <p><a id="dataLink" href="#" download>Download TOCS 2024 data (CSV)</a></p>
+  <script>
+    const user = window.location.hostname.split('.')[0];
+    const file = encodeURIComponent('TOCS 2024 Konstructive.csv');
+    document.getElementById('dataLink').href = `https://raw.githubusercontent.com/${user}/TOCS/main/${file}`;
+  </script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -212,7 +212,7 @@
               </svg>
             </button>
             <div id="calcDownloadMenu" class="absolute right-0 mt-2 bg-white border rounded shadow text-sm p-2 space-y-1 hidden">
-              <a id="calcDownloadCsv" href="download.html?type=calc" target="_blank" class="block w-full text-left">CSV</a>
+              <a id="calcDownloadCsv" href="data.html" target="_blank" class="block w-full text-left">CSV</a>
             </div>
           </div>
         </div>
@@ -250,7 +250,7 @@
               </svg>
             </button>
             <div id="downloadMenu" class="absolute right-0 mt-2 bg-white border rounded shadow text-sm p-2 space-y-1 hidden">
-              <a id="downloadCsv" href="download.html?type=occ" target="_blank" class="block w-full text-left">CSV</a>
+              <a id="downloadCsv" href="data.html" target="_blank" class="block w-full text-left">CSV</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add dedicated `data.html` page that links to the CSV data on raw.githubusercontent.com.
- Update download links in `index.html` to open the new standalone page.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a45837f324833282722673b5aec5be