### PR TITLE
fix: disable ligatures in dropdowns

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -92,6 +92,7 @@
       font-family:'DINPro','DIN Pro',Arial,sans-serif;
       font-feature-settings:'liga' 0;
       -webkit-font-feature-settings:'liga' 0;
+      -moz-font-feature-settings:'liga' 0;
       font-variant-ligatures:none;
     }
   </style>


### PR DESCRIPTION
## Summary
- ensure DINPro renders correctly in `<select>` dropdowns by disabling ligatures, preventing misrendering of "Sheffield"

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aed4d433b0832fbafc49a2235c46db