### PR TITLE
Update 2025 cost data and refine calculator UI

### DIFF
--- a/docs/costs.js
+++ b/docs/costs.js
@@ -1,1192 +1,1190 @@
-const COSTS =
-{
+const COSTS = {
   "Aberdeen": {
     "new": {
-      "netEffectiveRent": 30.06,
-      "rates": 10.27,
-      "annualisedCosts": 9.59,
-      "hardFM": 21.58,
-      "softFM": 10.39,
+      "annualisedCosts": 9.9,
+      "hardFM": 23.99,
       "managementFees": 2.03,
-      "totalSqft": 83.92,
-      "totalWorkstation": 8392.0
+      "netEffectiveRent": 30.06,
+      "rates": 10.44,
+      "softFM": 11.78,
+      "totalSqft": 88.21,
+      "totalWorkstation": 8820.56
     },
     "old": {
-      "netEffectiveRent": 20.56,
-      "rates": 9.332759531,
-      "annualisedCosts": 9.5944,
-      "hardFM": 25.74062234,
-      "softFM": 10.390016,
+      "annualisedCosts": 9.91,
+      "hardFM": 28.16,
       "managementFees": 1.74,
-      "totalSqft": 77.35779788,
-      "totalWorkstation": 7735.0
+      "netEffectiveRent": 20.17,
+      "rates": 8.95,
+      "softFM": 11.78,
+      "totalSqft": 80.7,
+      "totalWorkstation": 8070.12
     }
   },
   "Basingstoke": {
     "new": {
-      "netEffectiveRent": 23.93,
-      "rates": 11.11,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.57,
-      "softFM": 10.43,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.58,
       "managementFees": 1.87,
-      "totalSqft": 78.33,
-      "totalWorkstation": 7833.0
+      "netEffectiveRent": 31.35,
+      "rates": 13.32,
+      "softFM": 11.82,
+      "totalSqft": 91.69,
+      "totalWorkstation": 9169.29
     },
     "old": {
-      "netEffectiveRent": 15.26,
-      "rates": 9.092081159,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.9810467,
-      "softFM": 10.430016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.09,
       "managementFees": 1.57,
-      "totalSqft": 71.75434386,
-      "totalWorkstation": 7175.0
+      "netEffectiveRent": 17.33,
+      "rates": 10.27,
+      "softFM": 11.82,
+      "totalSqft": 78.84,
+      "totalWorkstation": 7884.28
     }
   },
   "Belfast": {
     "new": {
-      "netEffectiveRent": 21.0,
-      "rates": 8.76,
-      "annualisedCosts": 9.59,
-      "hardFM": 19.27,
-      "softFM": 10.17,
+      "annualisedCosts": 9.9,
+      "hardFM": 21.19,
       "managementFees": 1.75,
-      "totalSqft": 70.54,
-      "totalWorkstation": 7054.0
+      "netEffectiveRent": 22.95,
+      "rates": 11.3,
+      "softFM": 11.49,
+      "totalSqft": 78.59,
+      "totalWorkstation": 7858.55
     },
     "old": {
-      "netEffectiveRent": 16.2,
-      "rates": 6.7,
-      "annualisedCosts": 9.5944,
-      "hardFM": 23.91187866,
-      "softFM": 10.170016,
+      "annualisedCosts": 9.91,
+      "hardFM": 25.96,
       "managementFees": 1.58,
-      "totalSqft": 68.15629466,
-      "totalWorkstation": 6815.0
+      "netEffectiveRent": 16.2,
+      "rates": 9.3,
+      "softFM": 11.49,
+      "totalSqft": 74.43,
+      "totalWorkstation": 7443.41
     }
   },
   "Birmingham": {
     "new": {
-      "netEffectiveRent": 33.0,
-      "rates": 12.83,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.12,
-      "softFM": 10.6,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.01,
       "managementFees": 2.19,
-      "totalSqft": 88.33,
-      "totalWorkstation": 8833.0
+      "netEffectiveRent": 39.19,
+      "rates": 15.9,
+      "softFM": 11.99,
+      "totalSqft": 101.18,
+      "totalWorkstation": 10118.25
     },
     "old": {
-      "netEffectiveRent": 26.0,
-      "rates": 10.33039028,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.63725589,
-      "softFM": 10.600016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.64,
       "managementFees": 1.96,
-      "totalSqft": 83.12206217,
-      "totalWorkstation": 8312.0
+      "netEffectiveRent": 26.8,
+      "rates": 10.76,
+      "softFM": 11.99,
+      "totalSqft": 88.06,
+      "totalWorkstation": 8805.8
     }
   },
   "Bournemouth": {
     "new": {
-      "netEffectiveRent": 24.3,
-      "rates": 7.91,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.59,
-      "softFM": 10.26,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.57,
       "managementFees": 1.85,
-      "totalSqft": 74.5,
-      "totalWorkstation": 7449.0
+      "netEffectiveRent": 27.0,
+      "rates": 7.2,
+      "softFM": 11.61,
+      "totalSqft": 80.13,
+      "totalWorkstation": 8013.14
     },
     "old": {
-      "netEffectiveRent": 18.98,
-      "rates": 5.533610889,
-      "annualisedCosts": 9.5944,
-      "hardFM": 25.01801242,
-      "softFM": 10.260016,
+      "annualisedCosts": 9.91,
+      "hardFM": 27.11,
       "managementFees": 1.7,
-      "totalSqft": 71.08603931,
-      "totalWorkstation": 7108.0
+      "netEffectiveRent": 17.85,
+      "rates": 5.76,
+      "softFM": 11.61,
+      "totalSqft": 73.93,
+      "totalWorkstation": 7393.28
     }
   },
   "Bracknell": {
     "new": {
-      "netEffectiveRent": 26.4,
-      "rates": 8.93,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.51,
-      "softFM": 10.43,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.43,
       "managementFees": 1.96,
-      "totalSqft": 78.65,
-      "totalWorkstation": 7865.0
+      "netEffectiveRent": 26.81,
+      "rates": 8.76,
+      "softFM": 11.78,
+      "totalSqft": 82.49,
+      "totalWorkstation": 8249.26
     },
     "old": {
-      "netEffectiveRent": 18.98,
-      "rates": 8.246613797,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.86354443,
-      "softFM": 10.430016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.89,
       "managementFees": 1.7,
-      "totalSqft": 74.64137423,
-      "totalWorkstation": 7464.0
+      "netEffectiveRent": 19.8,
+      "rates": 7.72,
+      "softFM": 11.78,
+      "totalSqft": 78.64,
+      "totalWorkstation": 7864.41
     }
   },
   "Brighton": {
     "new": {
-      "netEffectiveRent": 34.69,
-      "rates": 10.46,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.71,
-      "softFM": 10.51,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.69,
       "managementFees": 2.19,
-      "totalSqft": 88.98,
-      "totalWorkstation": 8898.0
+      "netEffectiveRent": 39.6,
+      "rates": 10.0,
+      "softFM": 11.91,
+      "totalSqft": 97.15,
+      "totalWorkstation": 9714.88
     },
     "old": {
-      "netEffectiveRent": 27.0,
-      "rates": 9.789324614,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.07446079,
-      "softFM": 10.510016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.16,
       "managementFees": 1.94,
-      "totalSqft": 84.7350014,
-      "totalWorkstation": 8473.0
+      "netEffectiveRent": 29.75,
+      "rates": 9.72,
+      "softFM": 11.91,
+      "totalSqft": 91.24,
+      "totalWorkstation": 9123.78
     }
   },
   "Bristol": {
     "new": {
-      "netEffectiveRent": 35.77,
-      "rates": 11.28,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.49,
-      "softFM": 10.56,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.42,
       "managementFees": 2.27,
-      "totalSqft": 89.96,
-      "totalWorkstation": 8996.0
+      "netEffectiveRent": 40.4,
+      "rates": 11.79,
+      "softFM": 11.95,
+      "totalSqft": 98.74,
+      "totalWorkstation": 9873.66
     },
     "old": {
-      "netEffectiveRent": 29.75,
-      "rates": 7.548733412,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.9080874,
-      "softFM": 10.560016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.95,
       "managementFees": 2.05,
-      "totalSqft": 84.41123681,
-      "totalWorkstation": 8441.0
+      "netEffectiveRent": 36.75,
+      "rates": 9.98,
+      "softFM": 11.95,
+      "totalSqft": 97.59,
+      "totalWorkstation": 9758.7
     }
   },
   "Cambridge": {
     "new": {
-      "netEffectiveRent": 50.88,
-      "rates": 20.17,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.24,
-      "softFM": 10.35,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.18,
       "managementFees": 2.72,
-      "totalSqft": 114.78,
-      "totalWorkstation": 11478.0
+      "netEffectiveRent": 61.75,
+      "rates": 19.93,
+      "softFM": 11.74,
+      "totalSqft": 129.08,
+      "totalWorkstation": 12908.12
     },
     "old": {
-      "netEffectiveRent": 35.0,
-      "rates": 15.4998519,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.68003568,
-      "softFM": 10.350016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.73,
       "managementFees": 2.23,
-      "totalSqft": 98.18110359,
-      "totalWorkstation": 9818.0
+      "netEffectiveRent": 37.0,
+      "rates": 17.1,
+      "softFM": 11.74,
+      "totalSqft": 105.56,
+      "totalWorkstation": 10556.32
     }
   },
   "Cardiff": {
     "new": {
-      "netEffectiveRent": 21.46,
-      "rates": 9.98,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.13,
-      "softFM": 10.35,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.0,
       "managementFees": 1.77,
-      "totalSqft": 73.28,
-      "totalWorkstation": 7327.0
+      "netEffectiveRent": 24.03,
+      "rates": 9.7,
+      "softFM": 11.7,
+      "totalSqft": 79.1,
+      "totalWorkstation": 7910.3
     },
     "old": {
-      "netEffectiveRent": 13.73,
-      "rates": 8.885579846,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.5438182,
-      "softFM": 10.350016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.53,
       "managementFees": 1.51,
-      "totalSqft": 68.61381405,
-      "totalWorkstation": 6861.0
+      "netEffectiveRent": 17.17,
+      "rates": 9.11,
+      "softFM": 11.7,
+      "totalSqft": 75.93,
+      "totalWorkstation": 7593.13
     }
   },
   "Crawley": {
     "new": {
-      "netEffectiveRent": 23.1,
-      "rates": 10.36,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.47,
-      "softFM": 10.39,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.39,
       "managementFees": 1.84,
-      "totalSqft": 76.58,
-      "totalWorkstation": 7658.0
+      "netEffectiveRent": 33.25,
+      "rates": 11.39,
+      "softFM": 11.74,
+      "totalSqft": 91.36,
+      "totalWorkstation": 9136.4
     },
     "old": {
-      "netEffectiveRent": 18.15,
-      "rates": 8.56375039,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.90489748,
-      "softFM": 10.390016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.93,
       "managementFees": 1.67,
-      "totalSqft": 74.09986387,
-      "totalWorkstation": 7409.0
+      "netEffectiveRent": 24.75,
+      "rates": 10.29,
+      "softFM": 11.74,
+      "totalSqft": 86.14,
+      "totalWorkstation": 8613.74
     }
   },
   "Croydon": {
     "new": {
-      "netEffectiveRent": 32.81,
-      "rates": 14.8,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.82,
-      "softFM": 10.26,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.72,
       "managementFees": 2.15,
-      "totalSqft": 91.26,
-      "totalWorkstation": 9126.0
+      "netEffectiveRent": 37.19,
+      "rates": 15.75,
+      "softFM": 11.61,
+      "totalSqft": 100.18,
+      "totalWorkstation": 10018.18
     },
     "old": {
-      "netEffectiveRent": 25.81,
-      "rates": 10.00192742,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.08435853,
-      "softFM": 10.260016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.09,
       "managementFees": 1.91,
-      "totalSqft": 83.48750195,
-      "totalWorkstation": 8348.0
+      "netEffectiveRent": 28.44,
+      "rates": 14.18,
+      "softFM": 11.61,
+      "totalSqft": 93.99,
+      "totalWorkstation": 9398.96
     }
   },
   "Edinburgh": {
     "new": {
-      "netEffectiveRent": 41.44,
-      "rates": 10.89,
-      "annualisedCosts": 9.59,
-      "hardFM": 21.92,
-      "softFM": 10.51,
+      "annualisedCosts": 9.9,
+      "hardFM": 24.3,
       "managementFees": 2.38,
-      "totalSqft": 96.74,
-      "totalWorkstation": 9673.0
+      "netEffectiveRent": 43.32,
+      "rates": 13.02,
+      "softFM": 11.91,
+      "totalSqft": 104.83,
+      "totalWorkstation": 10483.17
     },
     "old": {
-      "netEffectiveRent": 28.5,
-      "rates": 9.322098389,
-      "annualisedCosts": 9.5944,
-      "hardFM": 26.11533708,
-      "softFM": 10.510016,
+      "annualisedCosts": 9.91,
+      "hardFM": 28.54,
       "managementFees": 1.97,
-      "totalSqft": 86.01185147,
-      "totalWorkstation": 8601.0
+      "netEffectiveRent": 30.06,
+      "rates": 11.6,
+      "softFM": 11.91,
+      "totalSqft": 93.99,
+      "totalWorkstation": 9399.21
     }
   },
   "Exeter": {
     "new": {
-      "netEffectiveRent": 23.13,
-      "rates": 9.28,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.12,
-      "softFM": 10.43,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.09,
       "managementFees": 1.81,
-      "totalSqft": 74.36,
-      "totalWorkstation": 7435.0
+      "netEffectiveRent": 23.13,
+      "rates": 7.2,
+      "softFM": 11.82,
+      "totalSqft": 75.96,
+      "totalWorkstation": 7595.67
     },
     "old": {
-      "netEffectiveRent": 19.89,
-      "rates": 5.205245462,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.49905883,
-      "softFM": 10.430016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.58,
       "managementFees": 1.7,
-      "totalSqft": 71.31872029,
-      "totalWorkstation": 7131.0
+      "netEffectiveRent": 19.89,
+      "rates": 5.35,
+      "softFM": 11.82,
+      "totalSqft": 75.24,
+      "totalWorkstation": 7524.13
     }
   },
   "Farnborough": {
     "new": {
-      "netEffectiveRent": 25.99,
-      "rates": 11.03,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.39,
-      "softFM": 10.51,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.3,
       "managementFees": 1.94,
-      "totalSqft": 80.28,
-      "totalWorkstation": 8027.0
+      "netEffectiveRent": 22.0,
+      "rates": 11.59,
+      "softFM": 11.86,
+      "totalSqft": 80.44,
+      "totalWorkstation": 8044.16
     },
     "old": {
-      "netEffectiveRent": 18.56,
-      "rates": 8.720879255,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.71963985,
-      "softFM": 10.510016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.73,
       "managementFees": 1.69,
-      "totalSqft": 74.62173511,
-      "totalWorkstation": 7462.0
+      "netEffectiveRent": 30.94,
+      "rates": 9.26,
+      "softFM": 11.86,
+      "totalSqft": 91.25,
+      "totalWorkstation": 9124.55
     }
   },
   "Glasgow": {
     "new": {
-      "netEffectiveRent": 29.29,
-      "rates": 10.92,
-      "annualisedCosts": 9.59,
-      "hardFM": 21.89,
-      "softFM": 10.51,
+      "annualisedCosts": 9.9,
+      "hardFM": 24.2,
       "managementFees": 2.06,
-      "totalSqft": 84.26,
-      "totalWorkstation": 8426.0
+      "netEffectiveRent": 35.62,
+      "rates": 13.15,
+      "softFM": 11.91,
+      "totalSqft": 96.85,
+      "totalWorkstation": 9684.83
     },
     "old": {
-      "netEffectiveRent": 24.75,
-      "rates": 7.4409441,
-      "annualisedCosts": 9.5944,
-      "hardFM": 26.14460996,
-      "softFM": 10.510016,
+      "annualisedCosts": 9.91,
+      "hardFM": 28.52,
       "managementFees": 1.9,
-      "totalSqft": 80.33997006,
-      "totalWorkstation": 8033.0
+      "netEffectiveRent": 25.75,
+      "rates": 8.21,
+      "softFM": 11.91,
+      "totalSqft": 86.19,
+      "totalWorkstation": 8619.35
     }
   },
   "Guildford": {
     "new": {
-      "netEffectiveRent": 33.0,
-      "rates": 14.47,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.8,
-      "softFM": 10.47,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.75,
       "managementFees": 2.19,
-      "totalSqft": 91.34,
-      "totalWorkstation": 9134.0
+      "netEffectiveRent": 39.19,
+      "rates": 15.07,
+      "softFM": 11.86,
+      "totalSqft": 101.81,
+      "totalWorkstation": 10180.87
     },
     "old": {
-      "netEffectiveRent": 21.04,
-      "rates": 12.48259172,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.18022749,
-      "softFM": 10.470016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.24,
       "managementFees": 1.77,
-      "totalSqft": 81.36403521,
-      "totalWorkstation": 8136.0
+      "netEffectiveRent": 24.0,
+      "rates": 13.81,
+      "softFM": 11.86,
+      "totalSqft": 89.44,
+      "totalWorkstation": 8944.24
     }
   },
   "Heathrow": {
     "new": {
-      "netEffectiveRent": 32.3,
-      "rates": 11.61,
-      "annualisedCosts": 10.42,
-      "hardFM": 21.24,
-      "softFM": 10.68,
+      "annualisedCosts": 10.75,
+      "hardFM": 23.18,
       "managementFees": 2.15,
-      "totalSqft": 88.41,
-      "totalWorkstation": 8840.0
+      "netEffectiveRent": 37.19,
+      "rates": 14.63,
+      "softFM": 12.07,
+      "totalSqft": 99.98,
+      "totalWorkstation": 9997.59
     },
     "old": {
-      "netEffectiveRent": 24.75,
-      "rates": 8.879168917,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.26343989,
-      "softFM": 10.680016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.69,
       "managementFees": 1.9,
-      "totalSqft": 81.89382481,
-      "totalWorkstation": 8189.0
+      "netEffectiveRent": 28.44,
+      "rates": 10.91,
+      "softFM": 12.07,
+      "totalSqft": 91.76,
+      "totalWorkstation": 9176.19
     }
   },
   "High Wycombe": {
     "new": {
-      "netEffectiveRent": 22.69,
-      "rates": 11.04,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.52,
-      "softFM": 10.39,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.43,
       "managementFees": 1.83,
-      "totalSqft": 76.89,
-      "totalWorkstation": 7688.0
+      "netEffectiveRent": 23.51,
+      "rates": 12.82,
+      "softFM": 11.74,
+      "totalSqft": 83.09,
+      "totalWorkstation": 8309.09
     },
     "old": {
-      "netEffectiveRent": 17.33,
-      "rates": 4.756759862,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.88215776,
-      "softFM": 10.390016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.91,
       "managementFees": 1.64,
-      "totalSqft": 69.42013362,
-      "totalWorkstation": 6942.0
+      "netEffectiveRent": 17.33,
+      "rates": 4.94,
+      "softFM": 11.74,
+      "totalSqft": 73.32,
+      "totalWorkstation": 7331.94
     }
   },
   "Leeds": {
     "new": {
-      "netEffectiveRent": 30.53,
-      "rates": 10.66,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.02,
-      "softFM": 10.47,
+      "annualisedCosts": 9.9,
+      "hardFM": 21.91,
       "managementFees": 2.1,
-      "totalSqft": 83.37,
-      "totalWorkstation": 8337.0
+      "netEffectiveRent": 39.31,
+      "rates": 11.91,
+      "softFM": 11.82,
+      "totalSqft": 96.95,
+      "totalWorkstation": 9695.12
     },
     "old": {
-      "netEffectiveRent": 22.28,
-      "rates": 8.828669023,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.49356969,
-      "softFM": 10.470016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.49,
       "managementFees": 1.81,
-      "totalSqft": 77.47665471,
-      "totalWorkstation": 7747.0
+      "netEffectiveRent": 29.6,
+      "rates": 9.48,
+      "softFM": 11.82,
+      "totalSqft": 89.11,
+      "totalWorkstation": 8910.82
     }
   },
   "Leicester": {
     "new": {
-      "netEffectiveRent": 16.5,
-      "rates": 7.46,
-      "annualisedCosts": 9.59,
-      "hardFM": 19.85,
-      "softFM": 10.31,
+      "annualisedCosts": 9.9,
+      "hardFM": 21.73,
       "managementFees": 1.61,
-      "totalSqft": 65.33,
-      "totalWorkstation": 6532.0
+      "netEffectiveRent": 19.59,
+      "rates": 7.49,
+      "softFM": 11.65,
+      "totalSqft": 71.97,
+      "totalWorkstation": 7196.88
     },
     "old": {
-      "netEffectiveRent": 15.26,
-      "rates": 5.409342594,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.33524751,
-      "softFM": 10.310016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.33,
       "managementFees": 1.57,
-      "totalSqft": 66.4790061,
-      "totalWorkstation": 6647.0
+      "netEffectiveRent": 15.26,
+      "rates": 5.53,
+      "softFM": 11.65,
+      "totalSqft": 70.25,
+      "totalWorkstation": 7024.89
     }
   },
   "Liverpool": {
     "new": {
-      "netEffectiveRent": 21.04,
-      "rates": 6.5,
-      "annualisedCosts": 9.59,
-      "hardFM": 19.99,
-      "softFM": 10.35,
+      "annualisedCosts": 9.9,
+      "hardFM": 21.9,
       "managementFees": 1.77,
-      "totalSqft": 69.24,
-      "totalWorkstation": 6924.0
+      "netEffectiveRent": 25.08,
+      "rates": 7.04,
+      "softFM": 11.74,
+      "totalSqft": 77.43,
+      "totalWorkstation": 7742.91
     },
     "old": {
-      "netEffectiveRent": 16.5,
-      "rates": 5.99179,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.44802983,
-      "softFM": 10.350016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.47,
       "managementFees": 1.61,
-      "totalSqft": 68.49423583,
-      "totalWorkstation": 6849.0
+      "netEffectiveRent": 16.5,
+      "rates": 6.72,
+      "softFM": 11.74,
+      "totalSqft": 72.95,
+      "totalWorkstation": 7294.92
     }
   },
   "London - City": {
     "new": {
-      "netEffectiveRent": 68.06,
-      "rates": 30.77,
-      "annualisedCosts": 11.25,
-      "hardFM": 22.07,
-      "softFM": 11.27,
+      "annualisedCosts": 11.61,
+      "hardFM": 24.07,
       "managementFees": 3.41,
-      "totalSqft": 146.83,
-      "totalWorkstation": 14682.0
+      "netEffectiveRent": 80.75,
+      "rates": 33.65,
+      "softFM": 12.74,
+      "totalSqft": 166.22,
+      "totalWorkstation": 16621.77
     },
     "old": {
-      "netEffectiveRent": 40.3,
-      "rates": 21.04339714,
-      "annualisedCosts": 11.248,
-      "hardFM": 25.98886413,
-      "softFM": 11.270016,
+      "annualisedCosts": 11.61,
+      "hardFM": 28.47,
       "managementFees": 2.48,
-      "totalSqft": 112.3302773,
-      "totalWorkstation": 11233.0
+      "netEffectiveRent": 44.0,
+      "rates": 23.01,
+      "softFM": 12.74,
+      "totalSqft": 122.31,
+      "totalWorkstation": 12230.77
     }
   },
   "London - Docklands": {
     "new": {
-      "netEffectiveRent": 42.63,
-      "rates": 23.47,
-      "annualisedCosts": 11.25,
-      "hardFM": 22.13,
-      "softFM": 10.97,
+      "annualisedCosts": 11.61,
+      "hardFM": 24.14,
       "managementFees": 2.57,
-      "totalSqft": 113.01,
-      "totalWorkstation": 11301.0
+      "netEffectiveRent": 43.6,
+      "rates": 25.37,
+      "softFM": 12.45,
+      "totalSqft": 119.73,
+      "totalWorkstation": 11972.96
     },
     "old": {
-      "netEffectiveRent": 24.27,
-      "rates": 16.56649793,
-      "annualisedCosts": 11.248,
-      "hardFM": 26.07396971,
-      "softFM": 10.970016,
+      "annualisedCosts": 11.61,
+      "hardFM": 28.57,
       "managementFees": 1.92,
-      "totalSqft": 91.04848363,
-      "totalWorkstation": 9104.0
+      "netEffectiveRent": 21.75,
+      "rates": 17.91,
+      "softFM": 12.45,
+      "totalSqft": 94.2,
+      "totalWorkstation": 9420.42
     }
   },
   "London - Hammersmith": {
     "new": {
-      "netEffectiveRent": 49.88,
-      "rates": 24.82,
-      "annualisedCosts": 11.25,
-      "hardFM": 22.01,
-      "softFM": 11.02,
+      "annualisedCosts": 11.61,
+      "hardFM": 24.02,
       "managementFees": 2.73,
-      "totalSqft": 121.71,
-      "totalWorkstation": 12171.0
+      "netEffectiveRent": 51.75,
+      "rates": 26.83,
+      "softFM": 12.49,
+      "totalSqft": 129.42,
+      "totalWorkstation": 12942.05
     },
     "old": {
-      "netEffectiveRent": 33.0,
-      "rates": 23.35649226,
-      "annualisedCosts": 11.248,
-      "hardFM": 25.93520363,
-      "softFM": 11.020016,
+      "annualisedCosts": 11.61,
+      "hardFM": 28.42,
       "managementFees": 2.19,
-      "totalSqft": 106.7497119,
-      "totalWorkstation": 10674.0
+      "netEffectiveRent": 33.0,
+      "rates": 25.24,
+      "softFM": 12.49,
+      "totalSqft": 112.96,
+      "totalWorkstation": 11295.55
     }
   },
   "London - Midtown": {
     "new": {
-      "netEffectiveRent": 66.0,
-      "rates": 22.56,
-      "annualisedCosts": 11.25,
-      "hardFM": 22.11,
-      "softFM": 11.27,
+      "annualisedCosts": 11.61,
+      "hardFM": 24.11,
       "managementFees": 3.33,
-      "totalSqft": 136.52,
-      "totalWorkstation": 13652.0
+      "netEffectiveRent": 72.19,
+      "rates": 24.38,
+      "softFM": 12.74,
+      "totalSqft": 148.36,
+      "totalWorkstation": 14835.65
     },
     "old": {
-      "netEffectiveRent": 45.38,
-      "rates": 19.72468334,
-      "annualisedCosts": 11.248,
-      "hardFM": 26.02621201,
-      "softFM": 11.270016,
+      "annualisedCosts": 11.61,
+      "hardFM": 28.51,
       "managementFees": 2.62,
-      "totalSqft": 116.2689114,
-      "totalWorkstation": 11626.0
+      "netEffectiveRent": 47.85,
+      "rates": 21.32,
+      "softFM": 12.74,
+      "totalSqft": 124.65,
+      "totalWorkstation": 12465.09
     }
   },
   "London - Southbank": {
     "new": {
-      "netEffectiveRent": 64.35,
-      "rates": 30.86,
-      "annualisedCosts": 11.25,
-      "hardFM": 22.02,
-      "softFM": 11.02,
+      "annualisedCosts": 11.61,
+      "hardFM": 24.02,
       "managementFees": 3.28,
-      "totalSqft": 142.78,
-      "totalWorkstation": 14278.0
+      "netEffectiveRent": 70.13,
+      "rates": 33.35,
+      "softFM": 12.49,
+      "totalSqft": 154.88,
+      "totalWorkstation": 15488.32
     },
     "old": {
-      "netEffectiveRent": 42.9,
-      "rates": 22.12292243,
-      "annualisedCosts": 11.248,
-      "hardFM": 25.9580077,
-      "softFM": 11.020016,
+      "annualisedCosts": 11.61,
+      "hardFM": 28.44,
       "managementFees": 2.53,
-      "totalSqft": 115.7789461,
-      "totalWorkstation": 11577.0
+      "netEffectiveRent": 42.9,
+      "rates": 23.91,
+      "softFM": 12.49,
+      "totalSqft": 121.88,
+      "totalWorkstation": 12188.21
     }
   },
   "London - West End Core": {
     "new": {
-      "netEffectiveRent": 113.63,
-      "rates": 54.26,
-      "annualisedCosts": 11.25,
-      "hardFM": 22.3,
-      "softFM": 11.27,
+      "annualisedCosts": 11.61,
+      "hardFM": 24.3,
       "managementFees": 4.95,
-      "totalSqft": 217.65,
-      "totalWorkstation": 21765.0
+      "netEffectiveRent": 148.75,
+      "rates": 58.64,
+      "softFM": 12.78,
+      "totalSqft": 261.03,
+      "totalWorkstation": 26102.51
     },
     "old": {
-      "netEffectiveRent": 61.88,
-      "rates": 49.28887078,
-      "annualisedCosts": 11.248,
-      "hardFM": 26.23261733,
-      "softFM": 11.270016,
+      "annualisedCosts": 11.61,
+      "hardFM": 28.71,
       "managementFees": 3.19,
-      "totalSqft": 163.1095041,
-      "totalWorkstation": 16310.0
+      "netEffectiveRent": 72.25,
+      "rates": 53.27,
+      "softFM": 12.78,
+      "totalSqft": 181.82,
+      "totalWorkstation": 18181.66
     }
   },
   "London - West End Non Core": {
     "new": {
-      "netEffectiveRent": 81.64,
-      "rates": 45.29,
-      "annualisedCosts": 11.25,
-      "hardFM": 21.95,
-      "softFM": 11.27,
+      "annualisedCosts": 11.61,
+      "hardFM": 23.96,
       "managementFees": 3.85,
-      "totalSqft": 175.25,
-      "totalWorkstation": 17524.0
+      "netEffectiveRent": 93.5,
+      "rates": 48.96,
+      "softFM": 12.78,
+      "totalSqft": 194.65,
+      "totalWorkstation": 19465.49
     },
     "old": {
-      "netEffectiveRent": 56.1,
-      "rates": 28.95569425,
-      "annualisedCosts": 11.248,
-      "hardFM": 25.86761836,
-      "softFM": 11.270016,
+      "annualisedCosts": 11.61,
+      "hardFM": 28.37,
       "managementFees": 2.99,
-      "totalSqft": 136.4313286,
-      "totalWorkstation": 13643.0
+      "netEffectiveRent": 59.5,
+      "rates": 31.3,
+      "softFM": 12.78,
+      "totalSqft": 146.54,
+      "totalWorkstation": 14654.32
     }
   },
   "Luton": {
     "new": {
-      "netEffectiveRent": 21.88,
-      "rates": 7.93,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.42,
-      "softFM": 10.37,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.34,
       "managementFees": 2.11,
-      "totalSqft": 73.13,
-      "totalWorkstation": 7312.0
+      "netEffectiveRent": 23.93,
+      "rates": 8.12,
+      "softFM": 11.68,
+      "totalSqft": 78.94,
+      "totalWorkstation": 7893.67
     },
     "old": {
-      "netEffectiveRent": 13.5,
-      "rates": 7.608525,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.85199192,
-      "softFM": 10.370016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.89,
       "managementFees": 1.93,
-      "totalSqft": 68.68173292,
-      "totalWorkstation": 6868.0
+      "netEffectiveRent": 22.5,
+      "rates": 7.9,
+      "softFM": 11.68,
+      "totalSqft": 81.66,
+      "totalWorkstation": 8166.28
     }
   },
   "Maidenhead": {
     "new": {
-      "netEffectiveRent": 33.83,
-      "rates": 13.85,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.57,
-      "softFM": 10.31,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.49,
       "managementFees": 2.22,
-      "totalSqft": 91.2,
-      "totalWorkstation": 9120.0
+      "netEffectiveRent": 43.31,
+      "rates": 17.23,
+      "softFM": 11.65,
+      "totalSqft": 107.65,
+      "totalWorkstation": 10765.13
     },
     "old": {
-      "netEffectiveRent": 25.58,
-      "rates": 11.85323481,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.95704965,
-      "softFM": 10.310016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.98,
       "managementFees": 1.93,
-      "totalSqft": 85.05150047,
-      "totalWorkstation": 8505.0
+      "netEffectiveRent": 25.58,
+      "rates": 12.9,
+      "softFM": 11.65,
+      "totalSqft": 89.8,
+      "totalWorkstation": 8979.72
     }
   },
   "Maidstone": {
     "new": {
-      "netEffectiveRent": 24.05,
-      "rates": 9.91,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.53,
-      "softFM": 10.26,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.49,
       "managementFees": 1.84,
-      "totalSqft": 77.01,
-      "totalWorkstation": 7701.0
+      "netEffectiveRent": 30.06,
+      "rates": 9.87,
+      "softFM": 11.61,
+      "totalSqft": 86.62,
+      "totalWorkstation": 8662.25
     },
     "old": {
-      "netEffectiveRent": 17.5,
-      "rates": 9.025323476,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.97473438,
-      "softFM": 10.260016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.04,
       "managementFees": 1.63,
-      "totalSqft": 73.81127386,
-      "totalWorkstation": 7381.0
+      "netEffectiveRent": 18.56,
+      "rates": 8.87,
+      "softFM": 11.61,
+      "totalSqft": 78.46,
+      "totalWorkstation": 7846.25
     }
   },
   "Manchester": {
     "new": {
-      "netEffectiveRent": 39.78,
-      "rates": 14.83,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.34,
-      "softFM": 10.43,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.27,
       "managementFees": 2.36,
-      "totalSqft": 97.33,
-      "totalWorkstation": 9733.0
+      "netEffectiveRent": 41.63,
+      "rates": 15.88,
+      "softFM": 11.78,
+      "totalSqft": 103.82,
+      "totalWorkstation": 10382.14
     },
     "old": {
-      "netEffectiveRent": 30.06,
-      "rates": 10.539675,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.86667845,
-      "softFM": 10.430016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.91,
       "managementFees": 2.03,
-      "totalSqft": 87.52076945,
-      "totalWorkstation": 8752.0
+      "netEffectiveRent": 29.75,
+      "rates": 11.43,
+      "softFM": 11.78,
+      "totalSqft": 91.81,
+      "totalWorkstation": 9181.06
     }
   },
   "Milton Keynes": {
     "new": {
-      "netEffectiveRent": 24.75,
-      "rates": 8.21,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.5,
-      "softFM": 10.39,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.4,
       "managementFees": 1.87,
-      "totalSqft": 76.15,
-      "totalWorkstation": 7614.0
+      "netEffectiveRent": 33.25,
+      "rates": 7.62,
+      "softFM": 11.78,
+      "totalSqft": 87.68,
+      "totalWorkstation": 8767.58
     },
     "old": {
-      "netEffectiveRent": 21.15,
-      "rates": 5.439495258,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.97075523,
-      "softFM": 10.390016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.98,
       "managementFees": 1.75,
-      "totalSqft": 74.12146648,
-      "totalWorkstation": 7412.0
+      "netEffectiveRent": 25.44,
+      "rates": 5.66,
+      "softFM": 11.78,
+      "totalSqft": 82.37,
+      "totalWorkstation": 8237.13
     }
   },
   "Newcastle": {
     "new": {
-      "netEffectiveRent": 25.75,
-      "rates": 9.76,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.14,
-      "softFM": 10.14,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.03,
       "managementFees": 1.92,
-      "totalSqft": 77.30,
-      "totalWorkstation": 7730.0
+      "netEffectiveRent": 30.4,
+      "rates": 11.27,
+      "softFM": 11.49,
+      "totalSqft": 87.01,
+      "totalWorkstation": 8701.33
     },
     "old": {
-      "netEffectiveRent": 21.88,
-      "rates": 9.019607409,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.58752905,
-      "softFM": 10.140016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.59,
       "managementFees": 1.79,
-      "totalSqft": 77.01155245,
-      "totalWorkstation": 7701.0
+      "netEffectiveRent": 24.05,
+      "rates": 9.97,
+      "softFM": 11.49,
+      "totalSqft": 83.79,
+      "totalWorkstation": 8378.88
     }
   },
   "Northampton": {
     "new": {
-      "netEffectiveRent": 20.25,
-      "rates": 6.07,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.06,
-      "softFM": 10.05,
+      "annualisedCosts": 9.9,
+      "hardFM": 21.97,
       "managementFees": 1.72,
-      "totalSqft": 67.74,
-      "totalWorkstation": 6774.0
+      "netEffectiveRent": 20.25,
+      "rates": 6.7,
+      "softFM": 11.4,
+      "totalSqft": 71.94,
+      "totalWorkstation": 7193.74
     },
     "old": {
-      "netEffectiveRent": 13.5,
-      "rates": 5.050720447,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.53376646,
-      "softFM": 10.050016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.55,
       "managementFees": 1.49,
-      "totalSqft": 64.21890291,
-      "totalWorkstation": 6421.0
+      "netEffectiveRent": 15.75,
+      "rates": 5.65,
+      "softFM": 11.4,
+      "totalSqft": 70.75,
+      "totalWorkstation": 7074.71
     }
   },
   "Norwich": {
     "new": {
-      "netEffectiveRent": 14.03,
-      "rates": 7.97,
-      "annualisedCosts": 9.59,
-      "hardFM": 19.72,
-      "softFM": 10.05,
+      "annualisedCosts": 9.9,
+      "hardFM": 21.6,
       "managementFees": 1.53,
-      "totalSqft": 62.9,
-      "totalWorkstation": 6289.0
+      "netEffectiveRent": 16.5,
+      "rates": 7.02,
+      "softFM": 11.4,
+      "totalSqft": 67.96,
+      "totalWorkstation": 6796.06
     },
     "old": {
-      "netEffectiveRent": 10.73,
-      "rates": 5.074305306,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.23213697,
-      "softFM": 10.050016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.23,
       "managementFees": 1.43,
-      "totalSqft": 61.11085827,
-      "totalWorkstation": 6111.0
+      "netEffectiveRent": 13.2,
+      "rates": 5.67,
+      "softFM": 11.4,
+      "totalSqft": 67.84,
+      "totalWorkstation": 6783.73
     }
   },
   "Nottingham": {
     "new": {
-      "netEffectiveRent": 21.88,
-      "rates": 7.31,
-      "annualisedCosts": 9.59,
-      "hardFM": 19.97,
-      "softFM": 10.05,
+      "annualisedCosts": 9.9,
+      "hardFM": 21.85,
       "managementFees": 1.78,
-      "totalSqft": 70.58,
-      "totalWorkstation": 7058.0
+      "netEffectiveRent": 24.06,
+      "rates": 7.26,
+      "softFM": 11.4,
+      "totalSqft": 76.26,
+      "totalWorkstation": 7625.86
     },
     "old": {
-      "netEffectiveRent": 16.09,
-      "rates": 4.667119863,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.46679661,
-      "softFM": 10.050016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.47,
       "managementFees": 1.6,
-      "totalSqft": 66.46833247,
-      "totalWorkstation": 6646.0
+      "netEffectiveRent": 16.5,
+      "rates": 4.48,
+      "softFM": 11.4,
+      "totalSqft": 70.36,
+      "totalWorkstation": 7035.93
     }
   },
   "Oxford": {
     "new": {
-      "netEffectiveRent": 57.81,
-      "rates": 10.85,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.57,
-      "softFM": 10.68,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.54,
       "managementFees": 2.95,
-      "totalSqft": 113.29,
-      "totalWorkstation": 11328.0
+      "netEffectiveRent": 60.13,
+      "rates": 11.06,
+      "softFM": 12.07,
+      "totalSqft": 119.51,
+      "totalWorkstation": 11950.73
     },
     "old": {
-      "netEffectiveRent": 37.0,
-      "rates": 9.092995636,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.02661436,
-      "softFM": 10.680016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.11,
       "managementFees": 2.26,
-      "totalSqft": 94.48082599,
-      "totalWorkstation": 9448.0
+      "netEffectiveRent": 43.94,
+      "rates": 11.02,
+      "softFM": 12.07,
+      "totalSqft": 107.15,
+      "totalWorkstation": 10715.16
     }
   },
   "Portsmouth": {
     "new": {
-      "netEffectiveRent": 27.75,
-      "rates": 8.74,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.28,
-      "softFM": 10.31,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.19,
       "managementFees": 1.96,
-      "totalSqft": 79.45,
-      "totalWorkstation": 7945.0
+      "netEffectiveRent": 32.38,
+      "rates": 10.23,
+      "softFM": 11.7,
+      "totalSqft": 89.22,
+      "totalWorkstation": 8921.64
     },
     "old": {
-      "netEffectiveRent": 21.0,
-      "rates": 7.320496797,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.73479738,
-      "softFM": 10.310016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.76,
       "managementFees": 1.75,
-      "totalSqft": 75.53651018,
-      "totalWorkstation": 7553.0
+      "netEffectiveRent": 20.63,
+      "rates": 10.17,
+      "softFM": 11.7,
+      "totalSqft": 81.77,
+      "totalWorkstation": 8177.42
     }
   },
   "Preston": {
     "new": {
-      "netEffectiveRent": 17.5,
-      "rates": 4.8,
-      "annualisedCosts": 9.59,
-      "hardFM": 19.96,
-      "softFM": 10.35,
+      "annualisedCosts": 9.9,
+      "hardFM": 21.88,
       "managementFees": 1.63,
-      "totalSqft": 63.83,
-      "totalWorkstation": 6383.0
+      "netEffectiveRent": 17.5,
+      "rates": 4.81,
+      "softFM": 11.7,
+      "totalSqft": 67.43,
+      "totalWorkstation": 6743.08
     },
     "old": {
-      "netEffectiveRent": 9.63,
-      "rates": 2.7728,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.45123365,
-      "softFM": 10.350016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.49,
       "managementFees": 1.39,
-      "totalSqft": 58.18844965,
-      "totalWorkstation": 5818.0
+      "netEffectiveRent": 9.63,
+      "rates": 3.25,
+      "softFM": 11.7,
+      "totalSqft": 62.36,
+      "totalWorkstation": 6236.45
     }
   },
   "Reading": {
     "new": {
-      "netEffectiveRent": 33.0,
-      "rates": 14.94,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.53,
-      "softFM": 10.39,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.42,
       "managementFees": 2.19,
-      "totalSqft": 91.47,
-      "totalWorkstation": 9147.0
+      "netEffectiveRent": 46.2,
+      "rates": 15.59,
+      "softFM": 11.74,
+      "totalSqft": 108.89,
+      "totalWorkstation": 10889.39
     },
     "old": {
-      "netEffectiveRent": 25.58,
-      "rates": 10.38748708,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.01502761,
-      "softFM": 10.390016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.03,
       "managementFees": 1.93,
-      "totalSqft": 83.7237307,
-      "totalWorkstation": 8372.0
+      "netEffectiveRent": 23.1,
+      "rates": 10.82,
+      "softFM": 11.74,
+      "totalSqft": 85.37,
+      "totalWorkstation": 8537.28
     }
   },
   "Richmond": {
     "new": {
-      "netEffectiveRent": 54.63,
-      "rates": 20.27,
-      "annualisedCosts": 10.42,
-      "hardFM": 21.02,
-      "softFM": 10.51,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.98,
       "managementFees": 2.83,
-      "totalSqft": 119.69,
-      "totalWorkstation": 11968.0
+      "netEffectiveRent": 56.25,
+      "rates": 24.51,
+      "softFM": 11.91,
+      "totalSqft": 129.24,
+      "totalWorkstation": 12923.55
     },
     "old": {
-      "netEffectiveRent": 42.75,
-      "rates": 17.78292878,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.40010252,
-      "softFM": 10.510016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.47,
       "managementFees": 2.47,
-      "totalSqft": 109.3342473,
-      "totalWorkstation": 10933.0
+      "netEffectiveRent": 44.55,
+      "rates": 22.18,
+      "softFM": 11.91,
+      "totalSqft": 119.34,
+      "totalWorkstation": 11933.93
     }
   },
   "Sheffield": {
     "new": {
-      "netEffectiveRent": 23.6,
-      "rates": 9.02,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.24,
-      "softFM": 10.26,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.13,
       "managementFees": 1.85,
-      "totalSqft": 74.56,
-      "totalWorkstation": 7456.0
+      "netEffectiveRent": 29.45,
+      "rates": 9.12,
+      "softFM": 11.61,
+      "totalSqft": 84.06,
+      "totalWorkstation": 8406.25
     },
     "old": {
-      "netEffectiveRent": 15.57,
-      "rates": 4.788124638,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.4672418,
-      "softFM": 10.260016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.46,
       "managementFees": 1.58,
-      "totalSqft": 66.25978243,
-      "totalWorkstation": 6625.0
+      "netEffectiveRent": 18.5,
+      "rates": 5.45,
+      "softFM": 11.61,
+      "totalSqft": 73.51,
+      "totalWorkstation": 7350.98
     }
   },
   "Slough": {
     "new": {
-      "netEffectiveRent": 31.35,
-      "rates": 12.21,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.66,
-      "softFM": 10.51,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.59,
       "managementFees": 2.13,
-      "totalSqft": 87.28,
-      "totalWorkstation": 8728.0
+      "netEffectiveRent": 31.97,
+      "rates": 13.74,
+      "softFM": 11.91,
+      "totalSqft": 93.09,
+      "totalWorkstation": 9309.35
     },
     "old": {
-      "netEffectiveRent": 16.5,
-      "rates": 8.778536243,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.13607076,
-      "softFM": 10.510016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.18,
       "managementFees": 1.61,
-      "totalSqft": 72.955823,
-      "totalWorkstation": 7295.0
+      "netEffectiveRent": 20.63,
+      "rates": 9.35,
+      "softFM": 11.91,
+      "totalSqft": 81.44,
+      "totalWorkstation": 8143.97
     }
   },
   "Southampton": {
     "new": {
-      "netEffectiveRent": 32.38,
-      "rates": 10.74,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.39,
-      "softFM": 10.39,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.32,
       "managementFees": 2.11,
-      "totalSqft": 86.43,
-      "totalWorkstation": 8643.0
+      "netEffectiveRent": 32.38,
+      "rates": 12.27,
+      "softFM": 11.74,
+      "totalSqft": 91.58,
+      "totalWorkstation": 9158.22
     },
     "old": {
-      "netEffectiveRent": 26.36,
-      "rates": 9.757890888,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.84374871,
-      "softFM": 10.390016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.89,
       "managementFees": 1.91,
-      "totalSqft": 83.6828556,
-      "totalWorkstation": 8368.0
+      "netEffectiveRent": 24.94,
+      "rates": 10.17,
+      "softFM": 11.74,
+      "totalSqft": 86.41,
+      "totalWorkstation": 8641.38
     }
   },
   "St Albans": {
     "new": {
-      "netEffectiveRent": 39.31,
-      "rates": 13.45,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.49,
-      "softFM": 10.43,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.41,
       "managementFees": 2.34,
-      "totalSqft": 96.44,
-      "totalWorkstation": 9643.0
+      "netEffectiveRent": 39.31,
+      "rates": 15.16,
+      "softFM": 11.82,
+      "totalSqft": 101.8,
+      "totalWorkstation": 10179.56
     },
     "old": {
-      "netEffectiveRent": 30.06,
-      "rates": 10.68093207,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.94401749,
-      "softFM": 10.430016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.99,
       "managementFees": 2.03,
-      "totalSqft": 88.56616556,
-      "totalWorkstation": 8856.0
+      "netEffectiveRent": 33.73,
+      "rates": 14.64,
+      "softFM": 11.82,
+      "totalSqft": 99.96,
+      "totalWorkstation": 9996.11
     }
   },
   "Staines": {
     "new": {
-      "netEffectiveRent": 32.81,
-      "rates": 14.57,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.52,
-      "softFM": 10.51,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.42,
       "managementFees": 2.15,
-      "totalSqft": 90.98,
-      "totalWorkstation": 9098.0
+      "netEffectiveRent": 34.2,
+      "rates": 17.42,
+      "softFM": 11.86,
+      "totalSqft": 98.8,
+      "totalWorkstation": 9880.5
     },
     "old": {
-      "netEffectiveRent": 24.75,
-      "rates": 10.60201421,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.99512997,
-      "softFM": 10.510016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.01,
       "managementFees": 1.9,
-      "totalSqft": 83.17836018,
-      "totalWorkstation": 8317.0
+      "netEffectiveRent": 23.1,
+      "rates": 14.78,
+      "softFM": 11.86,
+      "totalSqft": 89.41,
+      "totalWorkstation": 8941.35
     }
   },
   "Swansea": {
     "new": {
-      "netEffectiveRent": 12.4,
-      "rates": 5.42,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.12,
-      "softFM": 10.29,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.02,
       "managementFees": 1.81,
-      "totalSqft": 59.63,
-      "totalWorkstation": 5962.0
+      "netEffectiveRent": 12.67,
+      "rates": 5.69,
+      "softFM": 11.57,
+      "totalSqft": 63.66,
+      "totalWorkstation": 6366.16
     },
     "old": {
-      "netEffectiveRent": 8.25,
-      "rates": 2.8494,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.57778151,
-      "softFM": 10.290016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.59,
       "managementFees": 1.51,
-      "totalSqft": 57.07159751,
-      "totalWorkstation": 5707.0
+      "netEffectiveRent": 8.42,
+      "rates": 3.04,
+      "softFM": 11.57,
+      "totalSqft": 61.03,
+      "totalWorkstation": 6103.46
     }
   },
   "Swindon": {
     "new": {
-      "netEffectiveRent": 18.56,
-      "rates": 9.9,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.4,
-      "softFM": 10.17,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.29,
       "managementFees": 1.69,
-      "totalSqft": 70.31,
-      "totalWorkstation": 7031.0
+      "netEffectiveRent": 19.8,
+      "rates": 9.23,
+      "softFM": 11.53,
+      "totalSqft": 74.44,
+      "totalWorkstation": 7444.48
     },
     "old": {
-      "netEffectiveRent": 12.67,
-      "rates": 8.065538834,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.90121515,
-      "softFM": 10.170016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.92,
       "managementFees": 1.49,
-      "totalSqft": 66.89116999,
-      "totalWorkstation": 6689.0
+      "netEffectiveRent": 12.67,
+      "rates": 6.66,
+      "softFM": 11.53,
+      "totalSqft": 69.17,
+      "totalWorkstation": 6917.4
     }
   },
   "Uxbridge": {
     "new": {
-      "netEffectiveRent": 31.5,
-      "rates": 9.54,
-      "annualisedCosts": 10.42,
-      "hardFM": 21.33,
-      "softFM": 10.51,
+      "annualisedCosts": 10.75,
+      "hardFM": 23.29,
       "managementFees": 2.11,
-      "totalSqft": 85.41,
-      "totalWorkstation": 8541.0
+      "netEffectiveRent": 33.25,
+      "rates": 10.16,
+      "softFM": 11.86,
+      "totalSqft": 91.43,
+      "totalWorkstation": 9142.87
     },
     "old": {
-      "netEffectiveRent": 22.75,
-      "rates": 7.212012254,
-      "annualisedCosts": 10.4212,
-      "hardFM": 25.38997274,
-      "softFM": 10.510016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.85,
       "managementFees": 1.81,
-      "totalSqft": 78.093201,
-      "totalWorkstation": 7809.0
+      "netEffectiveRent": 21.0,
+      "rates": 7.3,
+      "softFM": 11.86,
+      "totalSqft": 80.58,
+      "totalWorkstation": 8058.44
     }
   },
   "Warrington": {
     "new": {
-      "netEffectiveRent": 20.35,
-      "rates": 7.9,
-      "annualisedCosts": 9.59,
-      "hardFM": 20.24,
-      "softFM": 10.29,
+      "annualisedCosts": 9.9,
+      "hardFM": 22.21,
       "managementFees": 1.6,
-      "totalSqft": 69.97,
-      "totalWorkstation": 6997.0
+      "netEffectiveRent": 21.0,
+      "rates": 7.9,
+      "softFM": 11.57,
+      "totalSqft": 74.18,
+      "totalWorkstation": 7418.45
     },
     "old": {
-      "netEffectiveRent": 14.66,
-      "rates": 5.1,
-      "annualisedCosts": 9.5944,
-      "hardFM": 24.73496233,
-      "softFM": 10.290016,
+      "annualisedCosts": 9.91,
+      "hardFM": 26.82,
       "managementFees": 1.45,
-      "totalSqft": 65.82937833,
-      "totalWorkstation": 6582.0
+      "netEffectiveRent": 14.85,
+      "rates": 5.1,
+      "softFM": 11.57,
+      "totalSqft": 69.69,
+      "totalWorkstation": 6969.16
     }
   },
   "Watford": {
     "new": {
-      "netEffectiveRent": 32.85,
-      "rates": 12.89,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.57,
-      "softFM": 10.51,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.48,
       "managementFees": 2.14,
-      "totalSqft": 89.38,
-      "totalWorkstation": 8937.0
+      "netEffectiveRent": 40.5,
+      "rates": 13.37,
+      "softFM": 11.86,
+      "totalSqft": 101.1,
+      "totalWorkstation": 10110.29
     },
     "old": {
-      "netEffectiveRent": 27.47,
-      "rates": 11.29117705,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.99872473,
-      "softFM": 10.510016,
+      "annualisedCosts": 10.76,
+      "hardFM": 27.02,
       "managementFees": 1.98,
-      "totalSqft": 86.67111778,
-      "totalWorkstation": 8667.0
+      "netEffectiveRent": 27.47,
+      "rates": 13.26,
+      "softFM": 11.86,
+      "totalSqft": 92.36,
+      "totalWorkstation": 9235.59
     }
   },
   "Woking": {
     "new": {
-      "netEffectiveRent": 30.53,
-      "rates": 13.75,
-      "annualisedCosts": 10.42,
-      "hardFM": 20.43,
-      "softFM": 10.51,
+      "annualisedCosts": 10.75,
+      "hardFM": 22.32,
       "managementFees": 2.1,
-      "totalSqft": 87.74,
-      "totalWorkstation": 8774.0
+      "netEffectiveRent": 37.13,
+      "rates": 15.39,
+      "softFM": 11.86,
+      "totalSqft": 99.56,
+      "totalWorkstation": 9955.71
     },
     "old": {
-      "netEffectiveRent": 19.8,
-      "rates": 11.38079104,
-      "annualisedCosts": 10.4212,
-      "hardFM": 24.80988704,
-      "softFM": 10.510016,
+      "annualisedCosts": 10.76,
+      "hardFM": 26.82,
       "managementFees": 1.73,
-      "totalSqft": 78.65189408,
-      "totalWorkstation": 7865.0
+      "netEffectiveRent": 23.6,
+      "rates": 13.3,
+      "softFM": 11.86,
+      "totalSqft": 88.07,
+      "totalWorkstation": 8806.69
     }
   }
-}
-;
+};

--- a/docs/data.html
+++ b/docs/data.html
@@ -5,10 +5,10 @@
   <title>TOCS Data Download</title>
 </head>
 <body>
-  <p><a id="dataLink" href="#" download>Download TOCS 2024 data (CSV)</a></p>
+  <p><a id="dataLink" href="#" download>Download TOCS 2025 data (CSV)</a></p>
   <script>
     const user = window.location.hostname.split('.')[0];
-    const file = encodeURIComponent('TOCS 2024 Konstructive.csv');
+    const file = encodeURIComponent('TOCS 2025 Konstructive.csv');
     document.getElementById('dataLink').href = `https://raw.githubusercontent.com/${user}/TOCS/main/${file}`;
   </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,6 +46,12 @@
       line-height:1.2;
       white-space:nowrap;
     }
+    .result-item{
+      background:#f9fafb;          /* gray-50 */
+      padding:0.75rem 1rem;        /* px-4 py-3 */
+      border-radius:0.375rem;      /* rounded */
+    }
+    .result-item + .result-item{margin-top:0.5rem;}
     .result-scroll{overflow-x:hidden;overflow-y:hidden;}
     .result-scroll.need-scroll{overflow-x:auto;}
     .result-title{white-space:nowrap;}
@@ -362,7 +368,7 @@
       const SQM_TO_SQFT = 10.76391041671;
       const DEFAULT_SQM_PER_PERSON = 10;
       function renderResult(el,label,valueStr,append=false){
-        const html=`<span class="result-label">${label}</span><span class="result-value">${valueStr}</span>`;
+        const html=`<div class="result-item"><span class="result-label">${label}</span><span class="result-value">${valueStr}</span></div>`;
         if(append) el.innerHTML+=html; else el.innerHTML=html;
       }
       function updateScrollbars(){


### PR DESCRIPTION
## Summary
- Refresh cost dataset using TOCS 2025 Konstructive.csv
- Update download link to 2025 CSV
- Polish space calculator output with card-style result items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aee6fd461c832fa03fd29cd5cd488f