### PR TITLE
Add optional cost customisation

### DIFF
--- a/docs/extras.js
+++ b/docs/extras.js
@@ -1,0 +1,380 @@
+const EXTRAS = {
+  "Aberdeen": {
+    "Post & Courier": 0.63,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Basingstoke": {
+    "Post & Courier": 0.65,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Belfast": {
+    "Post & Courier": 0.54,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Birmingham": {
+    "Post & Courier": 0.7,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Bournemouth": {
+    "Post & Courier": 0.58,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Bracknell": {
+    "Post & Courier": 0.63,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Brighton": {
+    "Post & Courier": 0.68,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Bristol": {
+    "Post & Courier": 0.69,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Cambridge": {
+    "Post & Courier": 0.62,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Cardiff": {
+    "Post & Courier": 0.61,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Crawley": {
+    "Post & Courier": 0.62,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Croydon": {
+    "Post & Courier": 0.58,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Edinburgh": {
+    "Post & Courier": 0.68,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Exeter": {
+    "Post & Courier": 0.65,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Farnborough": {
+    "Post & Courier": 0.66,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Glasgow": {
+    "Post & Courier": 0.68,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Guildford": {
+    "Post & Courier": 0.66,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Heathrow": {
+    "Post & Courier": 0.73,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "High Wycombe": {
+    "Post & Courier": 0.62,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Leeds": {
+    "Post & Courier": 0.65,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Leicester": {
+    "Post & Courier": 0.59,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Liverpool": {
+    "Post & Courier": 0.62,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "London - City": {
+    "Post & Courier": 0.95,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "London - Docklands": {
+    "Post & Courier": 0.85,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "London \u2013 Hammersmith": {
+    "Post & Courier": 0.87,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "London \u2013 Midtown": {
+    "Post & Courier": 0.95,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "London - Southbank": {
+    "Post & Courier": 0.87,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "London - West End core": {
+    "Post & Courier": 0.96,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "London West End fringe": {
+    "Post & Courier": 0.96,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Luton": {
+    "Post & Courier": 0.51,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Maidenhead": {
+    "Post & Courier": 0.59,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Maidstone": {
+    "Post & Courier": 0.58,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Manchester": {
+    "Post & Courier": 0.63,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Milton Keynes": {
+    "Post & Courier": 0.63,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Newcastle": {
+    "Post & Courier": 0.54,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Northampton": {
+    "Post & Courier": 0.51,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Norwich": {
+    "Post & Courier": 0.51,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Nottingham": {
+    "Post & Courier": 0.51,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Oxford": {
+    "Post & Courier": 0.73,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Portsmouth": {
+    "Post & Courier": 0.61,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Preston": {
+    "Post & Courier": 0.61,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Reading": {
+    "Post & Courier": 0.62,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Richmond": {
+    "Post & Courier": 0.68,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Sheffield": {
+    "Post & Courier": 0.58,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Slough": {
+    "Post & Courier": 0.68,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Southampton": {
+    "Post & Courier": 0.62,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "St Albans": {
+    "Post & Courier": 0.65,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Staines": {
+    "Post & Courier": 0.66,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Swansea": {
+    "Post & Courier": 0.48,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Swindon": {
+    "Post & Courier": 0.55,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Uxbridge": {
+    "Post & Courier": 0.66,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Warrington": {
+    "Post & Courier": 0.48,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Watford": {
+    "Post & Courier": 0.66,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  },
+  "Woking": {
+    "Post & Courier": 0.66,
+    "Catering": 4.35,
+    "Repographics": 4.1,
+    "Plants": 0.45,
+    "Furniture": 3.09
+  }
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -179,6 +179,8 @@
           <label for="peopleInput" class="block text-lg font-din-bold text-gray-700 mb-1">How many workstations?</label>
           <input type="number" id="peopleInput" class="w-full border rounded p-2" placeholder="e.g. 25" />
           <p id="peopleError" class="err-msg mt-1">Enter a number &gt; 0</p>
+          <button id="customiseToggle" type="button" class="text-lsh-red font-din-bold underline mt-2">Customise your costs</button>
+          <div id="extrasWrap" class="mt-2 p-2 border rounded hidden"></div>
         </div>
 
         <!-- Budget input -->
@@ -265,6 +267,7 @@
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
   <script src="costs.js"></script>
+  <script src="extras.js"></script>
   <script>
     if(typeof L==='undefined'){console.error('Leaflet failed to load.');}
     (function(){
@@ -341,9 +344,21 @@
           .replace(/fl/g,'f\u200Cl');
       }
       LOCS.forEach(loc=>{ loc.name = cleanName(loc.name); });
-
-
-
+      const EXTRAS_CLEAN={};
+      Object.keys(EXTRAS).forEach(k=>{
+        let clean=cleanName(k).replace(/\s{2,}/g,' - ');
+        EXTRAS_CLEAN[clean]=EXTRAS[k];
+      });
+      if(EXTRAS_CLEAN['London - West End core']){
+        EXTRAS_CLEAN['London - West End Core']=EXTRAS_CLEAN['London - West End core'];
+        delete EXTRAS_CLEAN['London - West End core'];
+      }
+      if(EXTRAS_CLEAN['London West End fringe']){
+        EXTRAS_CLEAN['London - West End Non Core']=EXTRAS_CLEAN['London West End fringe'];
+        delete EXTRAS_CLEAN['London West End fringe'];
+      }
+      const EXTRA_NAMES=Object.keys(EXTRAS_CLEAN[Object.keys(EXTRAS_CLEAN)[0]]||{});
+      const activeExtras=new Set(EXTRA_NAMES);
       const REGIONS=[
         {name:'All UK',center:[55.149843,-3.262972],zoom:4.5},
         {name:'London',center:[51.5072,-0.1276],zoom:11},
@@ -393,6 +408,8 @@
       let ageValue='';
       const pplInp=$('peopleInput'); const budInp=$('budgetInput');
       const pplGrp=$('peopleGroup'); const budGrp=$('budgetGroup');
+      const customiseToggle=$('customiseToggle');
+      const extrasWrap=$('extrasWrap');
       const calcBtn=$('calcBtn');
       const calcBtnWrap=$('calcBtnWrap');
       const areaR1=$('areaResult1'); const costR1=$('costResult1'); const pplR1=$('peopleResult1');
@@ -418,6 +435,31 @@
       const calcSection=$("calcSection");
       let occData=[];
       let showNew=true, showOld=true;
+
+      EXTRA_NAMES.forEach(name=>{
+        const row=document.createElement('div');
+        row.className='flex items-center justify-between mb-1';
+        const label=document.createElement('span');
+        label.textContent=name;
+        const cb=document.createElement('input');
+        cb.type='checkbox';
+        cb.checked=true;
+        cb.dataset.extra=name;
+        cb.className='h-4 w-4';
+        row.appendChild(label);
+        row.appendChild(cb);
+        extrasWrap.appendChild(row);
+      });
+      customiseToggle.addEventListener('click',()=>{
+        extrasWrap.classList.toggle('hidden');
+      });
+      extrasWrap.addEventListener('change',e=>{
+        if(e.target.matches('input[type="checkbox"]')){
+          const n=e.target.dataset.extra;
+          if(e.target.checked) activeExtras.add(n); else activeExtras.delete(n);
+          if(!resWrap.classList.contains('hidden')) performCalc(); else autoCalcIfReady();
+        }
+      });
       // populate locations dropdown with London first then major cities
       const londonLocs=LOCS
         .filter(l=>l.region==='London' && !l.regionMarker)
@@ -466,7 +508,14 @@
         const data=COSTS[loc];
         const age=AGE_MAP[ageValue];
         if(!data||!age||!data[age]) return 0;
-        return data[age].totalSqft*SQM_TO_SQFT;
+        let psf=data[age].totalSqft;
+        const extras=EXTRAS_CLEAN[loc];
+        if(extras){
+          EXTRA_NAMES.forEach(n=>{
+            if(!activeExtras.has(n)) psf-=extras[n]||0;
+          });
+        }
+        return psf*SQM_TO_SQFT;
       }
       function toggleInputs(){
         const showPeople=modeValue==='people';
@@ -476,6 +525,7 @@
         calcBtnWrap.classList.toggle('mt-3',!showPeople&&!showBudget);
         resWrap.classList.add('hidden');
         calcDownloadWrap.classList.add('hidden');
+        if(!showPeople) extrasWrap.classList.add('hidden');
         if(showPeople) calcBtn.textContent='Calculate cost';
         else if(showBudget) calcBtn.textContent='Calculate capacity';
         else calcBtn.textContent='Calculate';
@@ -665,6 +715,10 @@
         updateComparePrompt();
         toggleInputs();
         highlightSelections(false);
+        extrasWrap.classList.add('hidden');
+        activeExtras.clear();
+        EXTRA_NAMES.forEach(x=>activeExtras.add(x));
+        extrasWrap.querySelectorAll('input[type="checkbox"]').forEach(cb=>cb.checked=true);
       });
       removeLoc2.addEventListener('click',()=>{
         locSel2.value='';


### PR DESCRIPTION
## Summary
- add "Customise your costs" toggle with checkboxes to remove optional extras from calculations
- include per-area optional cost dataset for Post & Courier, Catering, Repographics, Plants and Furniture
- subtract deselected extras when computing per‑sqm cost and reset selections on clear

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68af0b66cbf4832f8538a5bbfa9ed526