### PR TITLE
Improve cost customisation UI and labels

### DIFF
--- a/TOCS Custom Extras 2025.csv
+++ b/TOCS Custom Extras 2025.csv
@@ -1,4 +1,4 @@
-Area,Post & Courier,Catering,Repographics,Plants,Furniture
+Area,Post & Courier,Catering,Printing & Reprographics,Plants,Furniture
 Aberdeen,0.63,4.35,4.10,0.45,3.09
 Basingstoke,0.65,4.35,4.10,0.45,3.09
 Belfast,0.54,4.35,4.10,0.45,3.09
@@ -23,8 +23,8 @@ Leicester,0.59,4.35,4.10,0.45,3.09
 Liverpool,0.62,4.35,4.10,0.45,3.09
 London - City,0.95,4.35,4.10,0.45,3.09
 London - Docklands,0.85,4.35,4.10,0.45,3.09
-London – Hammersmith,0.87,4.35,4.10,0.45,3.09
-London – Midtown,0.95,4.35,4.10,0.45,3.09
+London â€“ Hammersmith,0.87,4.35,4.10,0.45,3.09
+London â€“ Midtown,0.95,4.35,4.10,0.45,3.09
 London - Southbank,0.87,4.35,4.10,0.45,3.09
 London - West End core,0.96,4.35,4.10,0.45,3.09
 London West End fringe,0.96,4.35,4.10,0.45,3.09

--- a/docs/extras.js
+++ b/docs/extras.js
@@ -2,378 +2,378 @@ const EXTRAS = {
   "Aberdeen": {
     "Post & Courier": 0.63,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Basingstoke": {
     "Post & Courier": 0.65,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Belfast": {
     "Post & Courier": 0.54,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Birmingham": {
     "Post & Courier": 0.7,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Bournemouth": {
     "Post & Courier": 0.58,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Bracknell": {
     "Post & Courier": 0.63,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Brighton": {
     "Post & Courier": 0.68,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Bristol": {
     "Post & Courier": 0.69,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Cambridge": {
     "Post & Courier": 0.62,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Cardiff": {
     "Post & Courier": 0.61,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Crawley": {
     "Post & Courier": 0.62,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Croydon": {
     "Post & Courier": 0.58,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Edinburgh": {
     "Post & Courier": 0.68,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Exeter": {
     "Post & Courier": 0.65,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Farnborough": {
     "Post & Courier": 0.66,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Glasgow": {
     "Post & Courier": 0.68,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Guildford": {
     "Post & Courier": 0.66,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Heathrow": {
     "Post & Courier": 0.73,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "High Wycombe": {
     "Post & Courier": 0.62,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Leeds": {
     "Post & Courier": 0.65,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Leicester": {
     "Post & Courier": 0.59,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Liverpool": {
     "Post & Courier": 0.62,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "London - City": {
     "Post & Courier": 0.95,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "London - Docklands": {
     "Post & Courier": 0.85,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "London \u2013 Hammersmith": {
     "Post & Courier": 0.87,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "London \u2013 Midtown": {
     "Post & Courier": 0.95,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "London - Southbank": {
     "Post & Courier": 0.87,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "London - West End core": {
     "Post & Courier": 0.96,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "London West End fringe": {
     "Post & Courier": 0.96,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Luton": {
     "Post & Courier": 0.51,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Maidenhead": {
     "Post & Courier": 0.59,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Maidstone": {
     "Post & Courier": 0.58,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Manchester": {
     "Post & Courier": 0.63,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Milton Keynes": {
     "Post & Courier": 0.63,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Newcastle": {
     "Post & Courier": 0.54,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Northampton": {
     "Post & Courier": 0.51,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Norwich": {
     "Post & Courier": 0.51,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Nottingham": {
     "Post & Courier": 0.51,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Oxford": {
     "Post & Courier": 0.73,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Portsmouth": {
     "Post & Courier": 0.61,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Preston": {
     "Post & Courier": 0.61,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Reading": {
     "Post & Courier": 0.62,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Richmond": {
     "Post & Courier": 0.68,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Sheffield": {
     "Post & Courier": 0.58,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Slough": {
     "Post & Courier": 0.68,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Southampton": {
     "Post & Courier": 0.62,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "St Albans": {
     "Post & Courier": 0.65,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Staines": {
     "Post & Courier": 0.66,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Swansea": {
     "Post & Courier": 0.48,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Swindon": {
     "Post & Courier": 0.55,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Uxbridge": {
     "Post & Courier": 0.66,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Warrington": {
     "Post & Courier": 0.48,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Watford": {
     "Post & Courier": 0.66,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   },
   "Woking": {
     "Post & Courier": 0.66,
     "Catering": 4.35,
-    "Repographics": 4.1,
+    "Printing & Reprographics": 4.1,
     "Plants": 0.45,
     "Furniture": 3.09
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,7 @@
     .select-btn{ background:#e5e7eb; padding:0.25rem 0.5rem; border-radius:0.25rem; font-size:0.875rem; cursor:pointer; }
     .select-btn:hover{ background:#d1d5db; }
     .select-btn.active{ background:var(--lsh-red); color:#fff; }
+    input[type="checkbox"]{ accent-color:var(--lsh-red); }
     .error{ border-color:#dc2626!important; }
     .err-msg{ display:none; color:#dc2626; font-size:0.75rem; }
     /* result label (smaller, lighter) */
@@ -179,7 +180,11 @@
           <label for="peopleInput" class="block text-lg font-din-bold text-gray-700 mb-1">How many workstations?</label>
           <input type="number" id="peopleInput" class="w-full border rounded p-2" placeholder="e.g. 25" />
           <p id="peopleError" class="err-msg mt-1">Enter a number &gt; 0</p>
-          <button id="customiseToggle" type="button" class="text-lsh-red font-din-bold underline mt-2">Customise your costs</button>
+          <button id="customiseToggle" type="button" class="select-btn mt-2 flex items-center">Customise discretionary costs
+            <svg class="w-4 h-4 ml-1 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4" />
+            </svg>
+          </button>
           <div id="extrasWrap" class="mt-2 p-2 border rounded hidden"></div>
         </div>
 
@@ -409,6 +414,7 @@
       const pplInp=$('peopleInput'); const budInp=$('budgetInput');
       const pplGrp=$('peopleGroup'); const budGrp=$('budgetGroup');
       const customiseToggle=$('customiseToggle');
+      const custArrow=customiseToggle.querySelector('svg');
       const extrasWrap=$('extrasWrap');
       const calcBtn=$('calcBtn');
       const calcBtnWrap=$('calcBtnWrap');
@@ -452,6 +458,8 @@
       });
       customiseToggle.addEventListener('click',()=>{
         extrasWrap.classList.toggle('hidden');
+        customiseToggle.classList.toggle('active');
+        custArrow.classList.toggle('rotate-180');
       });
       extrasWrap.addEventListener('change',e=>{
         if(e.target.matches('input[type="checkbox"]')){
@@ -525,7 +533,11 @@
         calcBtnWrap.classList.toggle('mt-3',!showPeople&&!showBudget);
         resWrap.classList.add('hidden');
         calcDownloadWrap.classList.add('hidden');
-        if(!showPeople) extrasWrap.classList.add('hidden');
+        if(!showPeople){
+          extrasWrap.classList.add('hidden');
+          customiseToggle.classList.remove('active');
+          custArrow.classList.remove('rotate-180');
+        }
         if(showPeople) calcBtn.textContent='Calculate cost';
         else if(showBudget) calcBtn.textContent='Calculate capacity';
         else calcBtn.textContent='Calculate';


### PR DESCRIPTION
## Summary
- Replace "Customise your costs" link with a toggle button labelled "Customise discretionary costs" that shows a dropdown arrow and activates in LSH red
- Rename extra cost category from "Repographics" to "Printing & Reprographics"
- Style all checkboxes with LSH red accent colour

## Testing
- `node --check docs/extras.js`
- `npx -y htmlhint docs/index.html`


------
https://chatgpt.com/codex/tasks/task_b_68af10e124f8832fa91641d39d9b04c8