### PR TITLE
Revise hybrid calculator sliders and outputs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -122,6 +122,7 @@
     .density-point{display:none;}
     .density-label{margin-top:0;font-size:0.875rem;display:block;}
     .density-tooltip{display:none;}
+    .slider-pop{position:absolute;top:-1.5rem;left:50%;transform:translateX(-50%);background:#e5e7eb;padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.875rem;pointer-events:none;}
   </style>
 </head>
 <body class="bg-gray-50 antialiased">
@@ -189,13 +190,19 @@
         <p id="comparePrompt" class="text-sm text-gray-500 mb-3 hidden">Select another location on the map to compare results.</p>
 
         <label class="block text-lg font-din-bold text-gray-700 mb-1">Workstation density</label>
-        <div id="densitySlider" class="density-slider mb-1"></div>
+        <div id="densitySliderWrap" class="relative mb-1">
+          <input type="range" id="densitySlider" min="0" max="2" step="1" value="1" class="w-full" />
+          <output id="densityOutput" class="slider-pop"></output>
+        </div>
         <input type="hidden" id="densitySelect" value="10" />
 
         <div id="hybridLegacy" class="mt-4">
           <label class="block text-lg font-din-bold text-gray-700 mb-1">Hybrid extent</label>
           <p class="text-sm text-gray-600 font-din-light mb-1">How many workstations per member of staff?</p>
-          <div id="hybridSlider" class="density-slider mb-1"></div>
+          <div id="hybridSliderWrap" class="relative mb-1">
+            <input type="range" id="hybridSlider" min="0" max="4" step="1" value="0" class="w-full" />
+            <output id="hybridOutput" class="slider-pop"></output>
+          </div>
           <input type="hidden" id="hybridSelect" value="1" />
         </div>
 
@@ -300,7 +307,7 @@
   </main>
 
 
-  <div id="hybridModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-end justify-center hidden z-50" role="dialog" aria-modal="true">
+  <div id="hybridModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-end justify-center hidden" style="z-index:1000" role="dialog" aria-modal="true">
     <div class="bg-white rounded-t-lg w-full max-w-md p-4">
       <div class="flex justify-between items-center mb-2">
         <h3 class="text-xl font-din-bold">Right-size for Hybrid?</h3>
@@ -469,61 +476,39 @@
       const calcClear=$('calcClear');
       const densitySel=$('densitySelect');
       const densitySlider=$('densitySlider');
-      const densityOptions=[];
+      const densityOutput=$('densityOutput');
       const DENSITIES=[
         {label:'Dense',value:'8',detail:'8 m² per person NIA'},
         {label:'Standard',value:'10',detail:'10 m² per person NIA'},
         {label:'Spacious',value:'12.5',detail:'12.5 m² per person NIA'}
       ];
-      function setDensity(val){
-        densitySel.value=val;
-        densityOptions.forEach(o=>{
-          if(o.dataset.value===val) o.classList.add('selected');
-          else o.classList.remove('selected');
-        });
+      function updateDensity(){
+        const idx=parseInt(densitySlider.value,10);
+        const d=DENSITIES[idx];
+        densitySel.value=d.value;
+        densityOutput.textContent=d.label;
+        const pct=idx/(DENSITIES.length-1);
+        densityOutput.style.left=`${pct*100}%`;
+        densitySel.dispatchEvent(new Event('change'));
       }
-      DENSITIES.forEach(d=>{
-        const opt=document.createElement('button');
-        opt.type='button';
-        opt.className='density-option';
-        opt.dataset.value=d.value;
-        opt.textContent=d.label;
-        opt.title=d.detail;
-        opt.addEventListener('click',()=>{
-          setDensity(d.value);
-          densitySel.dispatchEvent(new Event('change'));
-        });
-        densityOptions.push(opt);
-        densitySlider.appendChild(opt);
-      });
-      setDensity('10');
+      densitySlider.addEventListener('input',updateDensity);
+      updateDensity();
 
       const hybridSel=$('hybridSelect');
       const hybridSlider=$('hybridSlider');
-      const hybridOptions=[];
+      const hybridOutput=$('hybridOutput');
       const HYBRID_RATIOS=[1,1.5,2,2.5,3];
-      function setHybrid(val){
-        hybridSel.value=val;
-        hybridOptions.forEach(o=>{
-          if(o.dataset.value===val) o.classList.add('selected');
-          else o.classList.remove('selected');
-        });
+      function updateHybrid(){
+        const idx=parseInt(hybridSlider.value,10);
+        const r=HYBRID_RATIOS[idx];
+        hybridSel.value=String(r);
+        hybridOutput.textContent=`1:${r}`;
+        const pct=idx/(HYBRID_RATIOS.length-1);
+        hybridOutput.style.left=`${pct*100}%`;
+        hybridSel.dispatchEvent(new Event('change'));
       }
-      HYBRID_RATIOS.forEach(r=>{
-        const opt=document.createElement('button');
-        opt.type='button';
-        opt.className='density-option';
-        opt.dataset.value=String(r);
-        opt.textContent=`1:${r}`;
-        opt.title=`1 workstation per ${r} staff`;
-        opt.addEventListener('click',()=>{
-          setHybrid(String(r));
-          hybridSel.dispatchEvent(new Event('change'));
-        });
-        hybridOptions.push(opt);
-        hybridSlider.appendChild(opt);
-      });
-      setHybrid('1');
+      hybridSlider.addEventListener('input',updateHybrid);
+      updateHybrid();
 
       let standardData=null;
       const hybridFab=$('hybridFab');
@@ -556,7 +541,7 @@
       });
       setDays('3');
 
-      function calcBusiestDay(headcount,densityPerPerson,originalMonthlyCost,d,anchorFactor,cpsqm){
+      function calcBusiestDay(headcount,densityPerPerson,originalAnnualCost,d,anchorFactor,cpsqm){
         const p=Math.min(Math.max(d/5,0),1);
         const mu=headcount*p;
         const sigma=Math.sqrt(headcount*p*(1-p));
@@ -567,39 +552,51 @@
         const D_peak=Math.min(headcount,Math.ceil(peakWithAnchor*smallTeamFactor));
         const workpointArea=D_peak*densityPerPerson;
         const totalArea=workpointArea;
-        const newMonthlyCost=Math.round(totalArea*cpsqm/12);
-        const savings=Math.max(originalMonthlyCost-newMonthlyCost,0);
-        const savingsPct=originalMonthlyCost>0?(savings/originalMonthlyCost)*100:0;
-        return{desks:D_peak,totalArea,newMonthlyCost,savings,savingsPct};
+        const newAnnualCost=Math.round(totalArea*cpsqm);
+        const savings=Math.max(originalAnnualCost-newAnnualCost,0);
+        const savingsPct=originalAnnualCost>0?(savings/originalAnnualCost)*100:0;
+        return{desks:D_peak,totalArea,newAnnualCost,savings,savingsPct};
       }
       hybridFab.addEventListener('click',()=>{hybridModal.classList.remove('hidden');updateHybridResults();});
       hybridClose.addEventListener('click',()=>hybridModal.classList.add('hidden'));
       document.addEventListener('keydown',e=>{if(e.key==='Escape')hybridModal.classList.add('hidden');});
       function updateHybridResults(){
-        if(!standardData) return;
+        if(!standardData || !standardData.length) return;
+        const sd=standardData[0];
         const d=parseFloat(daysRange.value);
         const anchor=parseFloat(anchorGroup.querySelector('input:checked').value);
-        const cpsqm=costPerSqm(standardData.location);
-        const r=calcBusiestDay(standardData.headcount,standardData.densityPerPerson,standardData.originalMonthlyCost,d,anchor,cpsqm);
-        renderResult(recResults,'Desks',r.desks.toLocaleString());
-        renderResult(recResults,'Total area',`${r.totalArea.toLocaleString()} m² / ${(r.totalArea*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`,true);
-        renderResult(recResults,'Original estimated monthly cost',`£${standardData.originalMonthlyCost.toLocaleString()}`,true);
-        renderResult(recResults,'Hybrid estimated monthly cost',`£${r.newMonthlyCost.toLocaleString()}`,true);
+        const cpsqm=costPerSqm(sd.location);
+        const r=calcBusiestDay(sd.headcount,sd.densityPerPerson,sd.originalAnnualCost,d,anchor,cpsqm);
+        renderResult(recResults,'Original space',`${sd.originalTotalArea.toLocaleString()} m² / ${(sd.originalTotalArea*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`);
+        renderResult(recResults,'Hybrid space',`${r.totalArea.toLocaleString()} m² / ${(r.totalArea*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`,true);
+        renderResult(recResults,'Original estimated annual cost',`£${sd.originalAnnualCost.toLocaleString()}`,true);
+        renderResult(recResults,'Hybrid estimated annual cost',`£${r.newAnnualCost.toLocaleString()}`,true);
         updateScrollbars();
       }
       daysRange.addEventListener('change',updateHybridResults);
       anchorGroup.addEventListener('change',updateHybridResults);
       function applyHybridResult(){
-        if(!standardData) return;
-        const cpsqm=costPerSqm(standardData.location);
+        if(!standardData || !standardData.length) return;
         const d=parseFloat(daysRange.value);
         const anchor=parseFloat(anchorGroup.querySelector('input:checked').value);
-        const r=calcBusiestDay(standardData.headcount,standardData.densityPerPerson,standardData.originalMonthlyCost,d,anchor,cpsqm);
         hybridTitle.textContent='Hybrid right-sizing';
-        renderResult(hybridMetrics,'Desks',r.desks.toLocaleString());
-        renderResult(hybridMetrics,'Total area',`${r.totalArea.toLocaleString()} m² / ${(r.totalArea*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`,true);
-        renderResult(hybridMetrics,'Original estimated monthly cost',`£${standardData.originalMonthlyCost.toLocaleString()}`,true);
-        renderResult(hybridMetrics,'Hybrid estimated monthly cost',`£${r.newMonthlyCost.toLocaleString()}`,true);
+        hybridMetrics.innerHTML='';
+        standardData.forEach(sd=>{
+          const cpsqm=costPerSqm(sd.location);
+          const r=calcBusiestDay(sd.headcount,sd.densityPerPerson,sd.originalAnnualCost,d,anchor,cpsqm);
+          const section=document.createElement('div');
+          const heading=document.createElement('h4');
+          heading.textContent=sd.location;
+          heading.className='font-din-bold';
+          section.appendChild(heading);
+          const metrics=document.createElement('div');
+          renderResult(metrics,'Original space',`${sd.originalTotalArea.toLocaleString()} m² / ${(sd.originalTotalArea*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`);
+          renderResult(metrics,'Hybrid space',`${r.totalArea.toLocaleString()} m² / ${(r.totalArea*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`,true);
+          renderResult(metrics,'Original estimated annual cost',`£${sd.originalAnnualCost.toLocaleString()}`,true);
+          renderResult(metrics,'Hybrid estimated annual cost',`£${r.newAnnualCost.toLocaleString()}`,true);
+          section.appendChild(metrics);
+          hybridMetrics.appendChild(section);
+        });
         hybridResult.classList.remove('hidden');
         updateScrollbars();
         hybridModal.classList.add('hidden');
@@ -1132,10 +1129,16 @@
         }
        calcLoc(locSel.value,areaR1,costR1,pplR1,title1);
        if(usePeople){
-         const cpsqm=costPerSqm(locSel.value);
          const sqm=n*sqmPerPerson;
-         const totalCost=Math.round(sqm*cpsqm);
-         standardData={headcount:n,densityPerPerson:sqmPerPerson,originalMonthlyCost:Math.round(totalCost/12),originalTotalArea:sqm,location:locSel.value};
+         standardData=[];
+         const cpsqm1=costPerSqm(locSel.value);
+         const totalCost1=Math.round(sqm*cpsqm1);
+         standardData.push({headcount:n,densityPerPerson:sqmPerPerson,originalAnnualCost:totalCost1,originalTotalArea:sqm,location:locSel.value});
+         if(locSel2.value){
+           const cpsqm2=costPerSqm(locSel2.value);
+           const totalCost2=Math.round(sqm*cpsqm2);
+           standardData.push({headcount:n,densityPerPerson:sqmPerPerson,originalAnnualCost:totalCost2,originalTotalArea:sqm,location:locSel2.value});
+         }
          hybridFab.classList.remove('hidden');
        }else{
          standardData=null;


### PR DESCRIPTION
## Summary
- Replace workstation density and hybrid extent inputs with range sliders and dynamic labels
- Improve hybrid right-sizing results with annual cost and space metrics for each location
- Ensure hybrid dialog overlays map correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b57476e5dc832f8d5a3500093f292d