### PR TITLE
Add hover explanations and revamp hybrid options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/docs/index.html
+++ b/docs/index.html
@@ -203,6 +203,7 @@
           <input type="range" id="densitySlider" min="0" max="2" step="1" value="1" class="absolute inset-0 w-full opacity-0 cursor-pointer" />
           <output id="densityOutput" class="slider-pop"></output>
         </div>
+        <div id="densityDetail" class="text-sm text-gray-600 font-din-light mt-1 hidden"></div>
         <input type="hidden" id="densitySelect" value="10" />
 
         <div id="hybridLegacy" class="mt-4">
@@ -213,6 +214,7 @@
             <input type="range" id="hybridSlider" min="0" max="4" step="1" value="0" class="absolute inset-0 w-full opacity-0 cursor-pointer" />
             <output id="hybridOutput" class="slider-pop"></output>
           </div>
+          <div id="hybridDetail" class="text-sm text-gray-600 font-din-light mt-1 hidden"></div>
           <input type="hidden" id="hybridSelect" value="1" />
         </div>
 
@@ -317,8 +319,8 @@
   </main>
 
 
-  <div id="hybridModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-end justify-center hidden" style="z-index:1000" role="dialog" aria-modal="true">
-    <div class="bg-white rounded-t-lg w-full max-w-md p-4">
+  <div id="hybridModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden" style="z-index:1000" role="dialog" aria-modal="true">
+    <div class="bg-white rounded-lg w-full max-w-md p-4">
       <div class="flex justify-between items-center mb-2">
         <h3 class="text-xl font-din-bold">Right-size for Hybrid?</h3>
         <button id="hybridClose" aria-label="Close" class="p-1">
@@ -332,12 +334,10 @@
         <label class="block text-lg font-din-bold text-gray-700 mb-1">Average days per week in the office per person</label>
         <div id="daysSlider" class="density-slider mb-1"></div>
         <input type="hidden" id="daysRange" value="3" />
-        <label class="block text-lg font-din-bold text-gray-700 mb-1">Do you have busy ‘anchor’ day(s)?</label>
-        <div class="flex gap-4 mb-1" id="anchorGroup">
-          <label class="flex items-center gap-1"><input type="radio" name="anchor" value="1" />No</label>
-          <label class="flex items-center gap-1"><input type="radio" name="anchor" value="1.2" checked />Sometimes</label>
-          <label class="flex items-center gap-1"><input type="radio" name="anchor" value="1.4" />Yes, very busy</label>
-        </div>
+        <label class="block text-lg font-din-bold text-gray-700 mb-1">Do you have any anchor days during the week?</label>
+        <div id="anchorDays" class="density-slider mb-1"></div>
+        <label id="anchorBusyLabel" class="block text-lg font-din-bold text-gray-700 mb-1 hidden">How busy is your anchor day(s)?</label>
+        <div id="anchorBusy" class="density-slider mb-1 hidden"></div>
         <div id="recResults" class="space-y-1"></div>
       </div>
       <div class="mt-4 text-right">
@@ -486,11 +486,12 @@
       const loc2Wrap=$('loc2Wrap');
       const comparePrompt=$('comparePrompt');
       const calcClear=$('calcClear');
-      const densitySel=$('densitySelect');
-      const densitySlider=$('densitySlider');
-      const densityOutput=$('densityOutput');
-      const densitySliderWrap=$('densitySliderWrap');
-      const densityDots=[];
+        const densitySel=$('densitySelect');
+        const densitySlider=$('densitySlider');
+        const densityOutput=$('densityOutput');
+        const densitySliderWrap=$('densitySliderWrap');
+        const densityDetail=$('densityDetail');
+        const densityDots=[];
       const DENSITIES=[
         {label:'Dense',value:'8',detail:'8 m² per person NIA'},
         {label:'Standard',value:'10',detail:'10 m² per person NIA'},
@@ -510,16 +511,33 @@
         densityDots.forEach((dot,i)=>{dot.classList.toggle('active',i===idx);});
         densitySel.dispatchEvent(new Event('change'));
       }
-      DENSITIES.forEach((_,i)=>{const dot=document.createElement('div');dot.className='step-dot';dot.style.left=`${(i/(DENSITIES.length-1))*100}%`;densitySliderWrap.appendChild(dot);densityDots.push(dot);});
-      densitySlider.addEventListener('input',updateDensity);
+        DENSITIES.forEach((d,i)=>{
+          const dot=document.createElement('div');
+          dot.className='step-dot';
+          dot.style.left=`${(i/(DENSITIES.length-1))*100}%`;
+          dot.addEventListener('mouseenter',()=>{densityDetail.textContent=`(${d.detail})`;densityDetail.classList.remove('hidden');});
+          dot.addEventListener('mouseleave',()=>densityDetail.classList.add('hidden'));
+          densitySliderWrap.appendChild(dot);
+          densityDots.push(dot);
+        });
+        densitySliderWrap.addEventListener('mouseleave',()=>densityDetail.classList.add('hidden'));
+        densitySlider.addEventListener('input',updateDensity);
       updateDensity();
 
-      const hybridSel=$('hybridSelect');
-      const hybridSlider=$('hybridSlider');
-      const hybridOutput=$('hybridOutput');
-      const hybridSliderWrap=$('hybridSliderWrap');
-      const hybridDots=[];
-      const HYBRID_RATIOS=[1,1.5,2,2.5,3];
+        const hybridSel=$('hybridSelect');
+        const hybridSlider=$('hybridSlider');
+        const hybridOutput=$('hybridOutput');
+        const hybridSliderWrap=$('hybridSliderWrap');
+        const hybridDetail=$('hybridDetail');
+        const hybridDots=[];
+        const HYBRID_RATIOS=[1,1.5,2,2.5,3];
+        const HYBRID_DETAILS=[
+          'Dedicated desk for each staff member',
+          'Desks for around two-thirds of staff',
+          'One desk for every two staff',
+          'Desks for 40% of staff',
+          'One desk for every three staff'
+        ];
       function updateHybrid(){
         const idx=parseInt(hybridSlider.value,10);
         const r=HYBRID_RATIOS[idx];
@@ -528,81 +546,145 @@
         hybridOutput.style.left=`${pct*100}%`;
         hybridDots.forEach((dot,i)=>{dot.classList.toggle('active',i===idx);});
       }
-      HYBRID_RATIOS.forEach((_,i)=>{const dot=document.createElement('div');dot.className='step-dot';dot.style.left=`${(i/(HYBRID_RATIOS.length-1))*100}%`;hybridSliderWrap.appendChild(dot);hybridDots.push(dot);});
-      hybridSlider.addEventListener('input',updateHybrid);
+        HYBRID_RATIOS.forEach((r,i)=>{
+          const dot=document.createElement('div');
+          dot.className='step-dot';
+          dot.style.left=`${(i/(HYBRID_RATIOS.length-1))*100}%`;
+          dot.addEventListener('mouseenter',()=>{hybridDetail.textContent=HYBRID_DETAILS[i];hybridDetail.classList.remove('hidden');});
+          dot.addEventListener('mouseleave',()=>hybridDetail.classList.add('hidden'));
+          hybridSliderWrap.appendChild(dot);
+          hybridDots.push(dot);
+        });
+        hybridSliderWrap.addEventListener('mouseleave',()=>hybridDetail.classList.add('hidden'));
+        hybridSlider.addEventListener('input',updateHybrid);
       updateHybrid();
 
       let standardData=null;
       let hybridApplied=false;
       const hybridFab=$('hybridFab');
-      const hybridModal=$('hybridModal');
-      const hybridClose=$('hybridClose');
-      const daysRange=$('daysRange');
-      const anchorGroup=$('anchorGroup');
-      const recResults=$('recResults');
-      const applyHybrid=$('applyHybrid');
-      const hybridResult=$('hybridResult');
-      const daysSliderEl=$('daysSlider');
-      const dayOptions=[];
-      const DAY_VALUES=[1,2,3,4,5];
-      function setDays(val){
+        const hybridModal=$('hybridModal');
+        const hybridClose=$('hybridClose');
+        const daysRange=$('daysRange');
+        const anchorDaysEl=$('anchorDays');
+        const anchorBusyEl=$('anchorBusy');
+        const anchorBusyLabel=$('anchorBusyLabel');
+        const recResults=$('recResults');
+        const applyHybrid=$('applyHybrid');
+        const hybridResult=$('hybridResult');
+        const daysSliderEl=$('daysSlider');
+        const dayOptions=[];
+        const anchorDayOptions=[];
+        const anchorBusyOptions=[];
+        const DAY_VALUES=[1,2,3,4,5];
+        let anchorDay='no';
+        let anchorBusy='0.8';
+        function setDays(val){
         daysRange.value=val;
         dayOptions.forEach(o=>{if(o.dataset.value===val)o.classList.add('selected'); else o.classList.remove('selected');});
         updateHybridResults();
       }
-      DAY_VALUES.forEach(v=>{
-        const opt=document.createElement('button');
-        opt.type='button';
-        opt.className='density-option';
-        opt.dataset.value=String(v);
-        opt.textContent=String(v);
-        opt.addEventListener('click',()=>setDays(String(v)));
-        dayOptions.push(opt);
-        daysSliderEl.appendChild(opt);
-      });
-      setDays('3');
+DAY_VALUES.forEach(v=>{
+  const opt=document.createElement('button');
+  opt.type='button';
+  opt.className='density-option';
+  opt.dataset.value=String(v);
+  opt.textContent=String(v);
+  opt.addEventListener('click',()=>setDays(String(v)));
+  dayOptions.push(opt);
+  daysSliderEl.appendChild(opt);
+});
+setDays('3');
 
-      function calcBusiestDay(headcount,densityPerPerson,originalAnnualCost,d,anchorFactor,cpsqm){
-        const p=Math.min(Math.max(d/5,0),1);
-        const mu=headcount*p;
-        const sigma=Math.sqrt(headcount*p*(1-p));
-        const z95=1.645;
-        const basePeak=mu+z95*sigma;
-        const peakWithAnchor=basePeak*anchorFactor;
-        const smallTeamFactor=headcount<30?1.05:1.00;
-        const D_peak=Math.min(headcount,Math.ceil(peakWithAnchor*smallTeamFactor));
-        const workpointArea=D_peak*densityPerPerson;
-        const totalArea=workpointArea;
-        const newAnnualCost=Math.round(totalArea*cpsqm);
-        const savings=Math.max(originalAnnualCost-newAnnualCost,0);
-        const savingsPct=originalAnnualCost>0?(savings/originalAnnualCost)*100:0;
-        return{desks:D_peak,totalArea,newAnnualCost,savings,savingsPct};
-      }
+        const ANCHOR_DAY_OPTS=[
+          {label:'No',value:'no'},
+          {label:'Yes',value:'yes'}
+        ];
+        function setAnchorDay(val){
+          anchorDay=val;
+          anchorDayOptions.forEach(o=>{o.classList.toggle('selected',o.dataset.value===val);});
+          const show=val==='yes';
+          anchorBusyEl.classList.toggle('hidden',!show);
+          anchorBusyLabel.classList.toggle('hidden',!show);
+          updateHybridResults();
+        }
+        ANCHOR_DAY_OPTS.forEach(opt=>{
+          const btn=document.createElement('button');
+          btn.type='button';
+          btn.className='density-option';
+          btn.dataset.value=opt.value;
+          btn.textContent=opt.label;
+          btn.addEventListener('click',()=>setAnchorDay(opt.value));
+          anchorDayOptions.push(btn);
+          anchorDaysEl.appendChild(btn);
+        });
+        setAnchorDay('no');
+
+        const ANCHOR_BUSY_OPTS=[
+          {label:'40% capacity',value:'0.4'},
+          {label:'60% capacity',value:'0.6'},
+          {label:'80% capacity',value:'0.8'},
+          {label:'Full capacity',value:'1'}
+        ];
+        function setAnchorBusy(val){
+          anchorBusy=val;
+          anchorBusyOptions.forEach(o=>{o.classList.toggle('selected',o.dataset.value===val);});
+          updateHybridResults();
+        }
+        ANCHOR_BUSY_OPTS.forEach(opt=>{
+          const btn=document.createElement('button');
+          btn.type='button';
+          btn.className='density-option';
+          btn.dataset.value=opt.value;
+          btn.textContent=opt.label;
+          btn.addEventListener('click',()=>setAnchorBusy(opt.value));
+          anchorBusyOptions.push(btn);
+          anchorBusyEl.appendChild(btn);
+        });
+        setAnchorBusy('0.8');
+
+        function calcBusiestDay(headcount,densityPerPerson,originalAnnualCost,d,anchorCapacity,cpsqm){
+          const p=Math.min(Math.max(d/5,0),1);
+          const mu=headcount*p;
+          const sigma=Math.sqrt(headcount*p*(1-p));
+          const z95=1.645;
+          const basePeak=mu+z95*sigma;
+          let peak=basePeak;
+          if(anchorCapacity!==null && !isNaN(anchorCapacity)){
+            peak=Math.max(basePeak,headcount*anchorCapacity);
+          }
+          const smallTeamFactor=headcount<30?1.05:1.00;
+          const D_peak=Math.min(headcount,Math.ceil(peak*smallTeamFactor));
+          const workpointArea=D_peak*densityPerPerson;
+          const totalArea=workpointArea;
+          const newAnnualCost=Math.round(totalArea*cpsqm);
+          const savings=Math.max(originalAnnualCost-newAnnualCost,0);
+          const savingsPct=originalAnnualCost>0?(savings/originalAnnualCost)*100:0;
+          return{desks:D_peak,totalArea,newAnnualCost,savings,savingsPct};
+        }
       hybridFab.addEventListener('click',()=>{hybridModal.classList.remove('hidden');updateHybridResults();});
       hybridClose.addEventListener('click',()=>hybridModal.classList.add('hidden'));
       document.addEventListener('keydown',e=>{if(e.key==='Escape')hybridModal.classList.add('hidden');});
       function updateHybridResults(){
         if(!standardData || !standardData.length) return;
         const sd=standardData[0];
-        const d=parseFloat(daysRange.value);
-        const anchor=parseFloat(anchorGroup.querySelector('input:checked').value);
-        const cpsqm=costPerSqm(sd.location);
-        const r=calcBusiestDay(sd.headcount,sd.densityPerPerson,sd.originalAnnualCost,d,anchor,cpsqm);
+          const d=parseFloat(daysRange.value);
+          const anchorCap=anchorDay==='yes'?parseFloat(anchorBusy):null;
+          const cpsqm=costPerSqm(sd.location);
+          const r=calcBusiestDay(sd.headcount,sd.densityPerPerson,sd.originalAnnualCost,d,anchorCap,cpsqm);
         renderResult(recResults,'Original space',`${sd.originalTotalArea.toLocaleString()} m² / ${(sd.originalTotalArea*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`);
         renderResult(recResults,'Hybrid space',`${r.totalArea.toLocaleString()} m² / ${(r.totalArea*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`,true,true);
         renderResult(recResults,'Original estimated annual cost',`£${sd.originalAnnualCost.toLocaleString()}`,true);
         renderResult(recResults,'Hybrid estimated annual cost',`£${r.newAnnualCost.toLocaleString()}`,true,true);
         updateScrollbars();
       }
-      daysRange.addEventListener('change',updateHybridResults);
-      anchorGroup.addEventListener('change',updateHybridResults);
+        daysRange.addEventListener('change',updateHybridResults);
       function applyHybridResult(){
         if(!standardData || !standardData.length) return;
-        const d=parseFloat(daysRange.value);
-        const anchor=parseFloat(anchorGroup.querySelector('input:checked').value);
-        standardData.forEach((sd,idx)=>{
-          const cpsqm=costPerSqm(sd.location);
-          const r=calcBusiestDay(sd.headcount,sd.densityPerPerson,sd.originalAnnualCost,d,anchor,cpsqm);
+          const d=parseFloat(daysRange.value);
+          const anchorCap=anchorDay==='yes'?parseFloat(anchorBusy):null;
+          standardData.forEach((sd,idx)=>{
+            const cpsqm=costPerSqm(sd.location);
+            const r=calcBusiestDay(sd.headcount,sd.densityPerPerson,sd.originalAnnualCost,d,anchorCap,cpsqm);
           const areaEl=idx===0?areaR1:areaR2;
           const costEl=idx===0?costR1:costR2;
           const pplEl=idx===0?pplR1:pplR2;


### PR DESCRIPTION
## Summary
- Add hover tooltips explaining workstation density and hybrid ratio options
- Center hybrid options modal and redesign anchor day questions with capacity choices
- Incorporate anchor day selections into hybrid calculations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b58059a454832f9e47740cea07041d