### PR TITLE
Rename hybrid working factor and fix workstation calculations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -206,8 +206,8 @@
         <input type="hidden" id="densitySelect" value="10" />
 
         <div id="hybridLegacy" class="mt-4">
-          <label class="block text-lg font-din-bold text-gray-700 mb-1">Extent of hybrid working</label>
-          <p class="text-sm text-gray-600 font-din-light mb-1">How many workstations per member of staff?</p>
+          <label class="block text-lg font-din-bold text-gray-700 mb-1">Hybrid working factor</label>
+          <p class="text-sm text-gray-600 font-din-light mb-1">How many staff per workstation?</p>
           <div id="hybridSliderWrap" class="relative mt-6 mb-8 step-slider">
             <div class="step-line"></div>
             <input type="range" id="hybridSlider" min="0" max="4" step="1" value="0" class="absolute inset-0 w-full opacity-0 cursor-pointer" />
@@ -217,9 +217,9 @@
           <input type="hidden" id="hybridSelect" value="1" />
         </div>
 
-        <!-- People input -->
+        <!-- Workstations input -->
         <div id="peopleGroup" class="mb-3 hidden">
-          <label for="peopleInput" class="block text-lg font-din-bold text-gray-700 mb-1">How many staff?</label>
+          <label for="peopleInput" class="block text-lg font-din-bold text-gray-700 mb-1">How many workstations?</label>
           <input type="number" id="peopleInput" class="w-full border rounded p-2" placeholder="e.g. 25" />
           <p id="peopleError" class="err-msg mt-1">Enter a number &gt; 0</p>
         </div>
@@ -1019,7 +1019,7 @@
           ['Space required (m\u00B2)','Space required (ft\u00B2)',...costHeaders]:
           ['Area achievable (m\u00B2)','Area achievable (ft\u00B2)','Workstations accommodated','Staff accommodated'];
         const budgetLabel=budgetPeriod==='monthly'?'Monthly budget (\u00A3)':'Annual budget (\u00A3)';
-        const header=['Location','Building age',usePeople?'Staff':budgetLabel,'Workstation density (m\u00B2 per person NIA)','Extent of hybrid working (workstations per staff)',...metricHeaders];
+        const header=['Location','Building age',usePeople?'Workstations':budgetLabel,'Workstation density (m\u00B2 per workstation NIA)','Hybrid working factor (staff per workstation)',...metricHeaders];
         const ageLabel=ageValue==='New'? 'New build':'20-yr old';
         const densityLabel=densitySel.value;
         const hybridLabel='1:'+hybridSel.value;
@@ -1032,9 +1032,7 @@
         function addRow(loc){
           const cpsqm=costPerSqm(loc);
           if(usePeople){
-            const staff=n;
-            const staffRatio=parseFloat(hybridSel.value || '1');
-            const workstations=Math.round(staff/staffRatio);
+            const workstations=n;
             const sqm=workstations*sqmPerPerson;
             const sqft=sqm*SQM_TO_SQFT;
             const cost=Math.round(sqm*cpsqm);
@@ -1044,7 +1042,7 @@
             lines.push([
               q(loc),
               ageLabel,
-              staff,
+              workstations,
               densityLabel,
               hybridLabel,
               sqm.toFixed(2),
@@ -1055,8 +1053,8 @@
           }else{
             const sqm=budget/cpsqm;
             const sqft=sqm*SQM_TO_SQFT;
-            const workstations=Math.round(sqm/sqmPerPerson);
-            const staff=Math.round(workstations*parseFloat(hybridSel.value || '1'));
+            const workstations=Math.floor(sqm/sqmPerPerson);
+            const staff=Math.floor(workstations*parseFloat(hybridSel.value || '1'));
             lines.push([
               q(loc),
               ageLabel,
@@ -1147,8 +1145,7 @@
          const cpsqm=costPerSqm(loc);
          titleEl.textContent=loc;
           if(usePeople){
-            const staff=n;
-            const workstations=Math.round(staff/staffPerWS);
+            const workstations=n;
             const sqm=workstations*sqmPerPerson;
             renderResult(areaEl,'Space required',`${sqm.toLocaleString()} m² / ${(sqm*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`);
             const totalCost=Math.round(sqm*cpsqm);
@@ -1161,8 +1158,8 @@
           }else{
             const sqm=budget/cpsqm;
             renderResult(areaEl,'Area required',`${Math.round(sqm).toLocaleString()} m² / ${Math.round(sqm*SQM_TO_SQFT).toLocaleString()} ft²`);
-            const workstations=Math.round(sqm/sqmPerPerson);
-            const staff=Math.round(workstations*staffPerWS);
+            const workstations=Math.floor(sqm/sqmPerPerson);
+            const staff=Math.floor(workstations*staffPerWS);
             renderResult(pplEl,'Workstations accommodated',`${workstations.toLocaleString()}`);
             renderResult(pplEl,'Staff accommodated',`${staff.toLocaleString()}`,true);
             const perWSAnnual=Math.round(budget/workstations);


### PR DESCRIPTION
## Summary
- rename "Extent of hybrid working" to "Hybrid working factor" and input label to "How many workstations?"
- correct CSV header and client copy for new terminology
- treat calculator input as number of workstations and use floor rounding to avoid zero-cost and overestimation scenarios

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`
- `python - <<'PY'
workstations=1
staff_per_ws=2.5
sqm_per_person=10
cpsqm=100
cost = workstations*sqm_per_person*cpsqm
print(cost)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68b5bd5631b4832fa0449012a7463b44