### PR TITLE
Fix hybrid working factor in space calculator

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -217,9 +217,9 @@
           <input type="hidden" id="hybridSelect" value="1" />
         </div>
 
-        <!-- Workstations input -->
+        <!-- Staff input -->
         <div id="peopleGroup" class="mb-3 hidden">
-          <label for="peopleInput" class="block text-lg font-din-bold text-gray-700 mb-1">How many workstations?</label>
+          <label for="peopleInput" class="block text-lg font-din-bold text-gray-700 mb-1">How many staff?</label>
           <input type="number" id="peopleInput" class="w-full border rounded p-2" placeholder="e.g. 25" />
           <p id="peopleError" class="err-msg mt-1">Enter a number &gt; 0</p>
         </div>
@@ -1019,20 +1019,22 @@
           ['Space required (m\u00B2)','Space required (ft\u00B2)',...costHeaders]:
           ['Area achievable (m\u00B2)','Area achievable (ft\u00B2)','Workstations accommodated','Staff accommodated'];
         const budgetLabel=budgetPeriod==='monthly'?'Monthly budget (\u00A3)':'Annual budget (\u00A3)';
-        const header=['Location','Building age',usePeople?'Workstations':budgetLabel,'Workstation density (m\u00B2 per workstation NIA)','Hybrid working factor (staff per workstation)',...metricHeaders];
+        const header=['Location','Building age',usePeople?'Staff':budgetLabel,'Workstation density (m\u00B2 per workstation NIA)','Hybrid working factor (staff per workstation)',...metricHeaders];
         const ageLabel=ageValue==='New'? 'New build':'20-yr old';
         const densityLabel=densitySel.value;
         const hybridLabel='1:'+hybridSel.value;
         const lines=['Lambert Smith Hampton', '', header.join(',')];
         const sqmPerPerson=parseFloat(densityLabel || DEFAULT_SQM_PER_PERSON);
         const n=usePeople?parseInt(pplInp.value,10):0;
+        const staffPerWS=parseFloat(hybridSel.value || '1');
         const inputBudget=!usePeople?parseInt(budInp.value.replace(/,/g,''),10):0;
         const budget=!usePeople?(budgetPeriod==='monthly'?inputBudget*12:inputBudget):0;
         function q(str){return `"${String(str).replace(/"/g,'""')}"`;}
         function addRow(loc){
           const cpsqm=costPerSqm(loc);
           if(usePeople){
-            const workstations=n;
+            const staff=n;
+            const workstations=Math.ceil(staff/staffPerWS);
             const sqm=workstations*sqmPerPerson;
             const sqft=sqm*SQM_TO_SQFT;
             const cost=Math.round(sqm*cpsqm);
@@ -1042,7 +1044,7 @@
             lines.push([
               q(loc),
               ageLabel,
-              workstations,
+              staff,
               densityLabel,
               hybridLabel,
               sqm.toFixed(2),
@@ -1145,16 +1147,17 @@
          const cpsqm=costPerSqm(loc);
          titleEl.textContent=loc;
           if(usePeople){
-            const workstations=n;
+            const staff=n;
+            const workstations=Math.ceil(staff/staffPerWS);
             const sqm=workstations*sqmPerPerson;
             renderResult(areaEl,'Space required',`${sqm.toLocaleString()} m² / ${(sqm*SQM_TO_SQFT).toLocaleString(undefined,{maximumFractionDigits:0})} ft²`);
+            renderResult(pplEl,'Workstations required',`${workstations.toLocaleString()}`);
+            pplEl.classList.remove('hidden');
             const totalCost=Math.round(sqm*cpsqm);
             const perWS=Math.round(cpsqm*sqmPerPerson);
             costEl.dataset.annualCost=totalCost;
             costEl.dataset.annualPerWs=perWS;
             costEl.innerHTML='';
-            pplEl.innerHTML='';
-            pplEl.classList.add('hidden');
           }else{
             const sqm=budget/cpsqm;
             renderResult(areaEl,'Area required',`${Math.round(sqm).toLocaleString()} m² / ${Math.round(sqm*SQM_TO_SQFT).toLocaleString()} ft²`);


### PR DESCRIPTION
## Summary
- Apply hybrid working factor when calculating space and cost
- Include staff inputs and hybrid ratio in CSV output
- Display workstations required based on selected hybrid factor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5c01fc2cc832f999edde2c47f1aa6