### PR TITLE
Use rounded rectangle contact photos

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -820,7 +820,7 @@
           const img=document.createElement('img');
           img.src=imgMap[name];
           img.alt=`Photo of ${name}`;
-          img.className='mb-3 w-32 h-32 object-cover rounded-full';
+          img.className='mb-3 w-32 h-40 object-cover rounded-lg';
           if(name==='Oliver Du Sautoy') img.style.objectPosition='center 60%';
           card.appendChild(img);
           const nm=document.createElement('div');


### PR DESCRIPTION
## Summary
- Show contact photos as rounded rectangles instead of circles on contact cards

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7062c2b18832faa68a6dff1c5e072