### PR TITLE
Align contact section with result output

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -855,10 +855,19 @@
       function showContacts(){
         loadContacts();
         contactSection.classList.remove('hidden');
+        requestAnimationFrame(()=>{
+          const heading=contactSection.querySelector('h3');
+          if(heading && title1){
+            const offset=title1.getBoundingClientRect().top-heading.getBoundingClientRect().top;
+            const current=parseFloat(getComputedStyle(contactSection).marginTop)||0;
+            contactSection.style.marginTop=`${current+offset}px`;
+          }
+        });
       }
 
       function hideContacts(){
         contactSection.classList.add('hidden');
+        contactSection.style.marginTop='';
       }
 
       function toggleInputs(){


### PR DESCRIPTION
## Summary
- Dynamically adjust margin so "Contact us" heading aligns with location result box
- Reset contact section margin when hidden

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b70763150c832fa371700635641810