### PR TITLE
Add animated lead form and cost chart axes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@
       scrollbar-gutter:stable both-edges;
       text-align:left;
     }
-    .result-scroll.need-scroll{overflow-x:auto;}
+    .result-scroll.need-scroll{overflow-x:auto;padding-right:0.5rem;}
     #resultContainer .result-scroll{
       display:flex;
       flex-wrap:wrap;
@@ -133,6 +133,11 @@
     /* allow occupancy bars to scroll horizontally */
     #occBars .bar-col{flex:1 0 8rem;}
     #occBars.placeholder{justify-content:space-evenly;padding:0 0.5rem;}
+    #occChart{position:relative;}
+    #yAxis{position:absolute;left:0;top:0;bottom:0;width:2rem;}
+    #yAxis:after{content:'';position:absolute;right:0;top:0;bottom:0;width:1px;background:#d1d5db;}
+    .y-tick{position:absolute;right:0;transform:translateX(-0.25rem);font-size:0.75rem;color:#4b5563;transition:bottom .3s ease;}
+    #xAxis{position:absolute;left:2rem;right:0;bottom:0;height:1px;background:#d1d5db;}
     button{transition:transform .1s ease;}
     button:active{transform:scale(.95);}
     .fade-in{animation:fadeIn .3s ease;}
@@ -394,7 +399,11 @@
             </div>
           </div>
         </div>
-        <div id="occBars" class="flex gap-4 items-end mb-4 w-full result-scroll"></div>
+        <div id="occChart" class="mb-4 relative w-full">
+          <div id="yAxis" class="hidden absolute left-0 top-0 bottom-0 w-8 text-xs text-gray-700"></div>
+          <div id="occBars" class="flex gap-4 items-end w-full h-56 result-scroll"></div>
+          <div id="xAxis" class="hidden absolute left-8 right-0 bottom-0 h-px bg-gray-300"></div>
+        </div>
         <p id="occLimitMsg" class="hidden text-xs text-lsh-red mb-2">You can compare up to 3 locations.</p>
         <div id="occTables"></div>
         <div id="occDownloadWrap" class="flex justify-end mt-2 hidden">
@@ -691,6 +700,46 @@
           el.classList.add('fade-in');
         });
       }
+      function animateLeadForm(){
+        leadWrap.classList.remove('hidden');
+        const card=leadWrap.querySelector('.bg-white');
+        card.classList.remove('fade-in');
+        card.style.opacity=0;
+        card.style.animationDelay='0s';
+        void card.offsetWidth;
+        card.classList.add('fade-in');
+        const items=card.querySelectorAll('.grid > div, label.flex, .text-right');
+        const count=items.length;
+        const step=count>1?0.6/(count-1):0;
+        items.forEach((el,i)=>{
+          el.classList.remove('fade-in');
+          el.style.opacity=0;
+          el.style.animationDelay=`${(0.3 + i*step).toFixed(2)}s`;
+          void el.offsetWidth;
+          el.classList.add('fade-in');
+        });
+      }
+      function scheduleLeadForm(){
+        clearTimeout(scheduleLeadForm.timer);
+        scheduleLeadForm.timer=setTimeout(animateLeadForm,900);
+      }
+      function updateYAxis(maxVal){
+        const yMax=Math.max(10,Math.ceil(maxVal/10)*10);
+        const step=yMax/4;
+        if(yAxisTicks.length===0){
+          for(let i=0;i<=4;i++){
+            const t=document.createElement('div');
+            t.className='y-tick';
+            yAxis.appendChild(t);
+            yAxisTicks.push(t);
+          }
+        }
+        yAxisTicks.forEach((tick,i)=>{
+          const value=Math.round(step*i/10)*10;
+          tick.textContent=`£${value}`;
+          tick.style.bottom=`${(value/yMax*100)}%`;
+        });
+      }
       function updateScrollbars(){
         document.querySelectorAll('.result-scroll').forEach(el=>{
           if(el.scrollWidth - el.clientWidth > 1) el.classList.add('need-scroll');
@@ -887,7 +936,9 @@
       const errs={mode:$('modeError'),location:$('locationError'),age:$('ageError'),people:$('peopleError'),budget:$('budgetError')};
       const calcWrap=$('calcWrapper'); const occWrap=$('occWrapper');
       const calcTab=$('calcTab'); const occTab=$('occTab');
-      const occBars=$("occBars"); const occTables=$("occTables"); const occClear=$("occClear"); const occPrompt=$("occPrompt");
+      const occChart=$("occChart"); const occBars=$("occBars"); const yAxis=$("yAxis"); const xAxis=$("xAxis");
+      const occTables=$("occTables"); const occClear=$("occClear"); const occPrompt=$("occPrompt");
+      let yAxisTicks=[];
       const occFilterBtn=$('occFilterBtn'); const occFilterMenu=$('occFilterMenu');
       const filterNew=$('filterNew'); const filterOld=$('filterOld');
       const occLimitMsg=$('occLimitMsg');
@@ -1191,14 +1242,22 @@
         occWrap.classList.remove('hidden');
         const hasData = occData.length > 0;
         occBars.classList.toggle('placeholder', !hasData);
+        occBars.classList.toggle('ml-8', hasData);
         occDownloadWrap.classList.toggle('hidden', !hasData);
         occUnits.classList.toggle('hidden', !hasData);
+        yAxis.classList.toggle('hidden', !hasData);
+        xAxis.classList.toggle('hidden', !hasData);
+        if(!hasData){
+          yAxisTicks.forEach(t=>t.remove());
+          yAxisTicks=[];
+        }
         let max=0;
         if(hasData){
           max=Math.max(...occData.flatMap(d=>[
             d.new?.totalSqft||0,
             d.old?.totalSqft||0
           ]));
+          updateYAxis(max);
         }
         occData.forEach((d,idx)=>{
           const col=document.createElement("div");
@@ -1337,6 +1396,7 @@
         activeExtras.clear();
         EXTRA_NAMES.forEach(x=>activeExtras.add(x));
         extrasWrap.querySelectorAll('input[type="checkbox"]').forEach(cb=>cb.checked=true);
+        leadWrap.classList.add('hidden');
       });
       removeLoc2.addEventListener('click',()=>{
         locSel2.value='';
@@ -1698,10 +1758,10 @@
         updateScrollbars();
         setTimeout(()=>{alignResultTitles(); updateScrollbars();},50);
 
-          // --- reveal lead form after any successful calculation ---
-          leadWrap.classList.remove('hidden');
+        // --- reveal lead form after result animation ---
+        scheduleLeadForm();
 
-          // --- build inputs snapshot for logging ---
+        // --- build inputs snapshot for logging ---
           const calcInputs = {
             ageValue,
             density: densitySel.value,


### PR DESCRIPTION
## Summary
- animate lead capture card after results finish animating
- fix table scroll clipping and add dynamic axes for per-sq-ft cost comparison

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b95de29840832fbba9e93b0b488022