### PR TITLE
Fix cost chart axis alignment

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1243,6 +1243,7 @@
         const hasData = occData.length > 0;
         occBars.classList.toggle('placeholder', !hasData);
         occBars.classList.toggle('ml-8', hasData);
+        occBars.classList.toggle('pr-4', hasData);
         occDownloadWrap.classList.toggle('hidden', !hasData);
         occUnits.classList.toggle('hidden', !hasData);
         yAxis.classList.toggle('hidden', !hasData);
@@ -1366,10 +1367,16 @@
           if(labsEl){
             const style=getComputedStyle(labsEl);
             const labelHeight=labsEl.offsetHeight+parseFloat(style.marginTop);
-            xAxis.style.bottom=labelHeight+"px";
+            const colStyle=getComputedStyle(labsEl.parentElement);
+            const extra=parseFloat(colStyle.paddingBottom)+parseFloat(colStyle.borderBottomWidth);
+            const offset=labelHeight+extra;
+            xAxis.style.bottom=offset+"px";
+            yAxis.style.bottom=offset+"px";
             xAxis.style.right='auto';
             const last=dataCols[dataCols.length-1];
-            const width=last.offsetLeft+last.offsetWidth;
+            const lastRect=last.getBoundingClientRect();
+            const barsRect=occBars.getBoundingClientRect();
+            const width=lastRect.right-barsRect.left;
             xAxis.style.width=width+"px";
           }
         }


### PR DESCRIPTION
## Summary
- ensure per sq ft cost chart x-axis aligns with y-axis zero and sits above labels
- add padding so third location bar no longer touches tile edge
- prevent x-axis from overlapping add-location placeholder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b9639731f0832fb3311027dfc37dd5