### PR TITLE
Tweak cost chart scaling and layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -839,44 +839,56 @@
         scheduleLeadForm.timer=setTimeout(animateLeadForm,900);
       }
       function updateYAxis(maxVal){
-        const yMax=Math.max(10,Math.ceil(maxVal/10)*10);
-        const step=yMax/4;
+        let step=5;
+        if(maxVal>100) step=50;
+        else if(maxVal>50) step=10;
 
-        if(yAxisTicks.length===0){
-          for(let i=0;i<=4;i++){
-            const t=document.createElement('div');
-            t.className='y-tick';
-            yAxis.appendChild(t);
-            yAxisTicks.push(t);
-          }
+        const yMax=Math.max(step,Math.ceil(maxVal/step)*step);
+        const needed=Math.round(yMax/step)+1;
+
+        while(yAxisTicks.length<needed){
+          const t=document.createElement('div');
+          t.className='y-tick';
+          yAxis.appendChild(t);
+          yAxisTicks.push(t);
+        }
+        while(yAxisTicks.length>needed){
+          const t=yAxisTicks.pop();
+          t.remove();
         }
         yAxisTicks.forEach((tick,i)=>{
-          const value=Math.round(step*i);
+          const value=step*i;
           tick.textContent=`£${value}`;
           tick.style.bottom=px((value / yMax) * BAR_MAX);
         });
 
-        return yMax;
+        return {yMax,step};
       }
 
-      function updateGridlines(yMax){
+      function updateGridlines(yMax,step){
         if(!gridLayer) return;
-        // Ensure 5 gridlines (0%, 25%, 50%, 75%, 100%)
-        while(gridLines.length<5){
+        const needed=Math.round(yMax/step)+1;
+        while(gridLines.length<needed){
           const gl=document.createElement('div');
           gl.className='y-gridline';
           gridLayer.appendChild(gl);
           gridLines.push(gl);
         }
-        while(gridLines.length>5){
+        while(gridLines.length>needed){
           const gl=gridLines.pop();
           gl.remove();
         }
-        const step=yMax/4;
         gridLines.forEach((gl,i)=>{
           const value=step*i;
           gl.style.bottom=px((value / yMax) * BAR_MAX);
         });
+      }
+
+      function standardiseLocLabels(){
+        const labels=[...occBars.querySelectorAll('.bar-col:not(.placeholder-col) .loc-label')];
+        labels.forEach(l=>l.style.height='auto');
+        const maxH=Math.max(0,...labels.map(l=>l.offsetHeight));
+        labels.forEach(l=>l.style.height=px(maxH));
       }
       function updateScrollbars(){
         document.querySelectorAll('.result-scroll').forEach(el=>{
@@ -1540,6 +1552,8 @@
           setTimeout(applyHeights,20);
         });
 
+        standardiseLocLabels();
+
         for(let i=occData.length;i<3;i++){
           const col=document.createElement('div');
           col.className='bar-col placeholder-col';
@@ -1574,9 +1588,9 @@
         }
 
         if(hasData){
-          const yMax=updateYAxis(max); // sets tick labels
-          updateGridlines(yMax);       // draws background lines at same heights
-          positionAxes();              // locks geometry (axis + grid layer)
+          const {yMax,step}=updateYAxis(max); // sets tick labels
+          updateGridlines(yMax,step);         // draws background lines at same heights
+          positionAxes();                      // locks geometry (axis + grid layer)
         }else{
           xAxis.style.width='0px';
           yAxis.style.height='0px';


### PR DESCRIPTION
## Summary
- Restrict y-axis scale to 5, 10 or 50 increments and align gridlines with labels
- Standardise location label boxes to the largest size for uniform columns

## Testing
- `node -e "require('./docs/costs.js'); console.log('costs loaded');"`


------
https://chatgpt.com/codex/tasks/task_b_68b98434e718832f977576081b502d56