### PR TITLE
feat: add Supabase event API and migration

### DIFF
--- a/app/api/event/route.ts
+++ b/app/api/event/route.ts
@@ -1,0 +1,135 @@
+import 'server-only';
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL as string;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function toNull(v: any) {
+  return v === '' || v === undefined ? null : v;
+}
+
+const numericFields = [
+  'workstation_density_m2',
+  'hybrid_factor',
+  'hybrid_occupancy',
+  'calc_seq',
+  'staff_input',
+  'space_required_sqft',
+  'workstations_required',
+  'annual_cost',
+  'cost_per_workstation_annual',
+  'cost_per_workstation_monthly',
+  'budget_value',
+];
+
+const booleanFields = ['marketing_opt_in', 'is_lead'];
+
+const stringFields = [
+  'page_url',
+  'page_referrer',
+  'user_agent',
+  'session_id',
+  'userid',
+  'calc_type',
+  'building_age',
+  'budget_type',
+  'location1',
+  'location2',
+  'company',
+  'contact_name',
+  'contact_email',
+  'contact_phone',
+];
+
+const allowedFields = [...numericFields, ...booleanFields, ...stringFields];
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders });
+}
+
+export async function POST(req: NextRequest) {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json(
+      { ok: false, error: 'Server misconfigured' },
+      { status: 500, headers: corsHeaders }
+    );
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid JSON' },
+      { status: 400, headers: corsHeaders }
+    );
+  }
+
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid payload' },
+      { status: 400, headers: corsHeaders }
+    );
+  }
+
+  const row: any = {};
+
+  // Timestamp handling
+  let createdAt = new Date();
+  if (body.ts) {
+    const ts = new Date(body.ts);
+    if (!isNaN(ts.getTime())) {
+      createdAt = ts;
+      row.event_ts = ts.toISOString();
+    }
+  }
+  row.created_at = createdAt.toISOString();
+
+  for (const key of allowedFields) {
+    const v = body[key];
+    if (v === undefined) continue; // ignore unknown
+    if (numericFields.includes(key)) {
+      const num = Number(v);
+      row[key] = Number.isFinite(num) ? num : null;
+    } else if (booleanFields.includes(key)) {
+      row[key] = v === true || v === 'true';
+    } else {
+      row[key] = toNull(v);
+    }
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('lsh_calculator_events')
+      .insert(row)
+      .select('id')
+      .single();
+
+    if (error) {
+      const status = error.message.includes('row-level security') ? 401 : 500;
+      return NextResponse.json(
+        { ok: false, error: error.message },
+        { status, headers: corsHeaders }
+      );
+    }
+
+    return NextResponse.json(
+      { ok: true, id: data.id },
+      { status: 200, headers: corsHeaders }
+    );
+  } catch (e: any) {
+    return NextResponse.json(
+      { ok: false, error: e.message ?? 'Unexpected error' },
+      { status: 500, headers: corsHeaders }
+    );
+  }
+}

--- a/express/event.js
+++ b/express/event.js
@@ -1,0 +1,113 @@
+const express = require('express');
+const { createClient } = require('@supabase/supabase-js');
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('Missing Supabase environment variables');
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const router = express.Router();
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function toNull(v) {
+  return v === '' || v === undefined ? null : v;
+}
+
+const numericFields = [
+  'workstation_density_m2',
+  'hybrid_factor',
+  'hybrid_occupancy',
+  'calc_seq',
+  'staff_input',
+  'space_required_sqft',
+  'workstations_required',
+  'annual_cost',
+  'cost_per_workstation_annual',
+  'cost_per_workstation_monthly',
+  'budget_value',
+];
+
+const booleanFields = ['marketing_opt_in', 'is_lead'];
+
+const stringFields = [
+  'page_url',
+  'page_referrer',
+  'user_agent',
+  'session_id',
+  'userid',
+  'calc_type',
+  'building_age',
+  'budget_type',
+  'location1',
+  'location2',
+  'company',
+  'contact_name',
+  'contact_email',
+  'contact_phone',
+];
+
+const allowedFields = [...numericFields, ...booleanFields, ...stringFields];
+
+router.options('/event', (req, res) => {
+  res.set(corsHeaders);
+  return res.status(204).end();
+});
+
+router.post('/event', async (req, res) => {
+  const body = req.body;
+  if (!body || typeof body !== 'object') {
+    return res.status(400).json({ ok: false, error: 'Invalid payload' });
+  }
+
+  const row = {};
+
+  let createdAt = new Date();
+  if (body.ts) {
+    const ts = new Date(body.ts);
+    if (!isNaN(ts.getTime())) {
+      createdAt = ts;
+      row.event_ts = ts.toISOString();
+    }
+  }
+  row.created_at = createdAt.toISOString();
+
+  for (const key of allowedFields) {
+    const v = body[key];
+    if (v === undefined) continue;
+    if (numericFields.includes(key)) {
+      const num = Number(v);
+      row[key] = Number.isFinite(num) ? num : null;
+    } else if (booleanFields.includes(key)) {
+      row[key] = v === true || v === 'true';
+    } else {
+      row[key] = toNull(v);
+    }
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('lsh_calculator_events')
+      .insert(row)
+      .select('id')
+      .single();
+
+    if (error) {
+      const status = error.message.includes('row-level security') ? 401 : 500;
+      return res.status(status).json({ ok: false, error: error.message });
+    }
+
+    return res.status(200).json({ ok: true, id: data.id });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+module.exports = router;

--- a/supabase/migrations/20240628_create_lsh_calculator_events.sql
+++ b/supabase/migrations/20240628_create_lsh_calculator_events.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS public.lsh_calculator_events (
+    id BIGSERIAL PRIMARY KEY,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    event_ts timestamptz,
+    page_url text,
+    page_referrer text,
+    user_agent text,
+    session_id text,
+    userid text,
+    calc_seq int,
+    calc_type text,
+    building_age text,
+    workstation_density_m2 numeric,
+    hybrid_factor numeric,
+    hybrid_occupancy numeric,
+    budget_type text,
+    location1 text,
+    location2 text,
+    staff_input numeric,
+    space_required_sqft numeric,
+    workstations_required numeric,
+    annual_cost numeric,
+    cost_per_workstation_annual numeric,
+    cost_per_workstation_monthly numeric,
+    budget_value numeric,
+    company text,
+    contact_name text,
+    contact_email text,
+    contact_phone text,
+    marketing_opt_in boolean DEFAULT false,
+    is_lead boolean DEFAULT false
+);
+
+ALTER TABLE public.lsh_calculator_events ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_lsh_events_created_at ON public.lsh_calculator_events (created_at);
+CREATE INDEX IF NOT EXISTS idx_lsh_events_event_ts ON public.lsh_calculator_events (event_ts);
+CREATE INDEX IF NOT EXISTS idx_lsh_events_session_calc_seq ON public.lsh_calculator_events (session_id, calc_seq);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'lsh_calculator_events' AND policyname = 'allow authenticated select'
+  ) THEN
+    CREATE POLICY "allow authenticated select"
+      ON public.lsh_calculator_events
+      FOR SELECT
+      TO authenticated
+      USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'lsh_calculator_events' AND policyname = 'allow service role insert'
+  ) THEN
+    CREATE POLICY "allow service role insert"
+      ON public.lsh_calculator_events
+      FOR INSERT
+      TO service_role
+      WITH CHECK (true);
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- add Supabase migration for lsh_calculator_events with RLS and policies
- implement Next.js route handler for posting events with type coercion & CORS
- provide Express handler sample

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b9bc3da530832fa1e8478660210da2