### PR TITLE
feat: store calculator leads in CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,12 @@
 
 ## Development
 
-This project now includes a simple Express server that logs calculator events to
-Supabase.
+This project includes a simple Express server that logs calculator events to
+`data/LSH_Calculator_Leads.csv`.
 
 ### Setup
 
-Create a `.env` file or export the following environment variables
-(a sample is provided in `.env.example`):
-
-- `SUPABASE_URL` – your Supabase project URL
-- `SUPABASE_SERVICE_ROLE_KEY` – service role key with insert permissions
-
-Then install dependencies and start the server:
+Install dependencies and start the server:
 
 ```sh
 npm install
@@ -21,4 +15,5 @@ npm start
 ```
 
 The server serves the static files from `docs/` and exposes an `/api/event`
-endpoint used by the calculator.
+endpoint used by the calculator. Submitted data is appended to
+`data/LSH_Calculator_Leads.csv`.

--- a/server.js
+++ b/server.js
@@ -46,7 +46,8 @@ const stringFields = [
 const allowedFields = [...numericFields, ...booleanFields, ...stringFields];
 
 const DATA_DIR = path.join(__dirname, 'data');
-const CSV_PATH = path.join(DATA_DIR, 'submissions.csv');
+// Path for storing calculator leads in a CSV for easy retrieval
+const CSV_PATH = path.join(DATA_DIR, 'LSH_Calculator_Leads.csv');
 const csvHeaders = ['created_at', 'event_ts', ...allowedFields];
 
 fs.mkdirSync(DATA_DIR, { recursive: true });


### PR DESCRIPTION
## Summary
- persist calculator submissions to `data/LSH_Calculator_Leads.csv`
- document new CSV logging behaviour in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68baa78fcf38832fa83b34758d1e7a78