### PR TITLE
feat: add supabase analytics routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-SUPABASE_URL=https://gtjyewrhtzvhghfthati.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imd0anlld3JodHp2aGdoZnRoYXRpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY4OTQwNzQsImV4cCI6MjA3MjQ3MDA3NH0.M08J92PDe-V3_8fF_D7J-gWvXa0itaB5PoREIVp73wg
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE=your-service-role-key

--- a/app/api/event/route.ts
+++ b/app/api/event/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from 'next/server';
+import { supabase } from '@/lib/supabase-server';
+import { cors, isAllowedOrigin } from '@/lib/cors';
+import { sanitizeEvent } from '@/lib/sanitize';
+
+export async function OPTIONS(req: NextRequest) {
+  return new Response(null, { headers: cors(req) });
+}
+
+async function rateLimit(row: Record<string, any>) {
+  if (!row.session_id || row.calc_seq === undefined) return false;
+  const { data } = await supabase
+    .from('calc_events')
+    .select('ts')
+    .eq('session_id', row.session_id)
+    .eq('calc_seq', row.calc_seq)
+    .order('ts', { ascending: false })
+    .limit(1)
+    .single();
+  if (!data) return false;
+  return Date.now() - new Date(data.ts).getTime() < 300;
+}
+
+export async function POST(req: NextRequest) {
+  if (!isAllowedOrigin(req)) {
+    return new Response('forbidden', { status: 403, headers: cors(req) });
+  }
+
+  const payload = await req.json().catch(() => null);
+  if (!payload) {
+    return new Response('bad request', { status: 400, headers: cors(req) });
+  }
+
+  const nowIso = new Date().toISOString();
+  const ip = (req.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || '';
+
+  const rows = Array.isArray(payload) ? payload : [payload];
+  const cleanRows = rows.map((r: any) => {
+    const row = sanitizeEvent(r);
+    row.ts = row.ts || nowIso;
+    row.ip = ip;
+    return row;
+  });
+
+  for (const row of cleanRows) {
+    if (await rateLimit(row)) {
+      return new Response('too many requests', { status: 429, headers: cors(req) });
+    }
+  }
+
+  const { error } = await supabase.from('calc_events').insert(cleanRows);
+  if (error) {
+    return new Response('server error', { status: 500, headers: cors(req) });
+  }
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json', ...cors(req) },
+  });
+}

--- a/app/api/lead/route.ts
+++ b/app/api/lead/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from 'next/server';
+import { supabase } from '@/lib/supabase-server';
+import { cors, isAllowedOrigin } from '@/lib/cors';
+import { sanitizeLead } from '@/lib/sanitize';
+
+export async function OPTIONS(req: NextRequest) {
+  return new Response(null, { headers: cors(req) });
+}
+
+async function rateLimit(row: Record<string, any>) {
+  if (!row.session_id || row.calc_seq === undefined) return false;
+  const { data } = await supabase
+    .from('calc_events')
+    .select('ts')
+    .eq('session_id', row.session_id)
+    .eq('calc_seq', row.calc_seq)
+    .order('ts', { ascending: false })
+    .limit(1)
+    .single();
+  if (!data) return false;
+  return Date.now() - new Date(data.ts).getTime() < 300;
+}
+
+export async function POST(req: NextRequest) {
+  if (!isAllowedOrigin(req)) {
+    return new Response('forbidden', { status: 403, headers: cors(req) });
+  }
+
+  const payload = await req.json().catch(() => null);
+  if (!payload) {
+    return new Response('bad request', { status: 400, headers: cors(req) });
+  }
+
+  const nowIso = new Date().toISOString();
+  const ip = (req.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || '';
+
+  const rows = Array.isArray(payload) ? payload : [payload];
+  const cleanRows = rows.map((r: any) => {
+    const row = sanitizeLead(r);
+    row.ts = row.ts || nowIso;
+    row.ip = ip;
+    return row;
+  });
+
+  for (const row of cleanRows) {
+    if (await rateLimit(row)) {
+      return new Response('too many requests', { status: 429, headers: cors(req) });
+    }
+  }
+
+  const { error } = await supabase.from('calc_events').insert(cleanRows);
+  if (error) {
+    return new Response('server error', { status: 500, headers: cors(req) });
+  }
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json', ...cors(req) },
+  });
+}

--- a/lib/cors.ts
+++ b/lib/cors.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from 'next/server';
+
+export const allowedOrigins = [
+  'https://example.com',
+  'https://www.example.com',
+  'http://localhost:3000',
+];
+
+export function isAllowedOrigin(req: NextRequest | Request): boolean {
+  const origin = req.headers.get('origin');
+  return origin ? allowedOrigins.includes(origin) : false;
+}
+
+export function cors(req: Request): Record<string, string> {
+  const origin = req.headers.get('origin');
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+  };
+  if (origin && allowedOrigins.includes(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin;
+  }
+  return headers;
+}

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -1,0 +1,132 @@
+const allowlistFields = [
+  'ts',
+  'page_url',
+  'page_referrer',
+  'user_agent',
+  'ip',
+  'session_id',
+  'calc_seq',
+  'calc_type',
+  'building_age',
+  'workstation_density_m2',
+  'hybrid_factor',
+  'hybrid_occupancy',
+  'budget_type',
+  'location1',
+  'location2',
+  'staff_input',
+  'budget_value',
+  'space_required_sqft',
+  'workstations_required',
+  'annual_cost',
+  'cost_per_workstation_annual',
+  'cost_per_workstation_monthly',
+  'company',
+  'contact_name',
+  'contact_email',
+  'contact_phone',
+  'marketing_opt_in',
+  'is_lead',
+];
+
+const numericFields = new Set([
+  'workstation_density_m2',
+  'hybrid_factor',
+  'hybrid_occupancy',
+  'budget_value',
+  'annual_cost',
+  'cost_per_workstation_annual',
+  'cost_per_workstation_monthly',
+]);
+
+const integerFields = new Set([
+  'calc_seq',
+  'space_required_sqft',
+  'workstations_required',
+  'staff_input',
+]);
+
+function toNumber(value: any): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  if (typeof value === 'string') value = value.replace(/,/g, '');
+  const num = Number(value);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+function sanitizeString(value: any): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  const str = String(value).trim().slice(0, 2000);
+  return str;
+}
+
+export function sanitizeBase(obj: Record<string, any>): Record<string, any> {
+  const clean: Record<string, any> = {};
+  for (const key of allowlistFields) {
+    const value = obj[key];
+    if (value === undefined || value === null) continue;
+    if (numericFields.has(key)) {
+      const num = toNumber(value);
+      if (num !== undefined) clean[key] = num;
+      continue;
+    }
+    if (integerFields.has(key)) {
+      const num = toNumber(value);
+      if (num !== undefined) clean[key] = Math.trunc(num);
+      continue;
+    }
+    if (key === 'marketing_opt_in' || key === 'is_lead') {
+      clean[key] = Boolean(value);
+      continue;
+    }
+    if (key === 'calc_type') {
+      const s = sanitizeString(value);
+      if (s === 'people' || s === 'budget') clean[key] = s;
+      continue;
+    }
+    if (key === 'building_age') {
+      const s = sanitizeString(value);
+      if (s === 'New' || s === '20') clean[key] = s;
+      continue;
+    }
+    const str = sanitizeString(value);
+    if (str !== undefined) clean[key] = str;
+  }
+  if (clean.is_lead === undefined) clean.is_lead = false;
+  return clean;
+}
+
+function stripDanger(str: string): string {
+  return str.replace(/[<>"'`;]/g, '');
+}
+
+export function sanitizeEvent(obj: Record<string, any>): Record<string, any> {
+  const row = sanitizeBase(obj);
+  row.company = '';
+  row.contact_name = '';
+  row.contact_email = '';
+  row.contact_phone = '';
+  row.marketing_opt_in = false;
+  row.is_lead = false;
+  return row;
+}
+
+export function sanitizeLead(obj: Record<string, any>): Record<string, any> {
+  const row = sanitizeBase(obj);
+  row.is_lead = true;
+  row.company = stripDanger(row.company || '');
+  row.contact_name = stripDanger(row.contact_name || '');
+  if (row.contact_email) {
+    const email = stripDanger(row.contact_email).replace(/[^\w@.+-]/g, '');
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    row.contact_email = emailRegex.test(email) ? email : '';
+  } else {
+    row.contact_email = '';
+  }
+  row.contact_phone = row.contact_phone
+    ? row.contact_phone.replace(/[^\d+()\-\s]/g, '')
+    : '';
+  row.marketing_opt_in = Boolean(row.marketing_opt_in);
+  return row;
+}
+
+export { allowlistFields };

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!,
+  { auth: { persistSession: false } }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,106 @@
       "name": "tocs",
       "version": "1.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.57.0",
         "express": "^4.19.2"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
+      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.4.tgz",
+      "integrity": "sha512-e/FYIWjvQJHOCNACWehnKvg26zosju3694k0NMUNb+JGLdvHJzEa29ZVVLmawd2kvx4hdbv8mxSqfttRnH3+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.1.tgz",
+      "integrity": "sha512-kaKCJZcZrHDCO9L76bEPzNv2caCStOigOUioHw7CvdEzvcSKjVuomRfN2Y9EqXmJH4tEHoBi3tCs/Ye2e3HwDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.0.tgz",
+      "integrity": "sha512-h9ttcL0MY4h+cGqZl95F/RuqccuRBjHU9B7Qqvw0Da+pPK2sUlU1/UdvyqUGj37UsnSphr9pdGfeXjesYkBcyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.3",
+        "@supabase/realtime-js": "2.15.4",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/accepts": {
@@ -788,6 +887,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -800,6 +905,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -826,6 +937,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "node --check server.js"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.57.0",
     "express": "^4.19.2"
   }
 }


### PR DESCRIPTION
## Summary
- add server-side Supabase client and CORS helpers
- sanitize payloads and expose POST handlers for analytics and leads
- update env example and dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68baad040b34832fa2ae09259b5647b8